### PR TITLE
⬆️ Upgrade pnpm to v11

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -22,7 +22,7 @@
       }
     },
     {
-      "files": ["**/*.css", "**/*.js", "**/*.json", "**/*.yml"],
+      "files": ["**/*.css", "**/*.js", "**/*.json", "**/*.yml", "**/*.yaml"],
       "options": {
         "tabWidth": 2
       }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,5 @@
     "tailwindcss": "4.3.3",
     "vite": "8.2.1"
   },
-  "packageManager": "pnpm@10.34.5"
+  "packageManager": "pnpm@11.22.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# pnpm 11 reads its settings from this file (no longer from .npmrc or package.json#pnpm).
+
+# Dependency build scripts are opt-in. core-js-pure's postinstall only prints a
+# funding banner, so it is explicitly denied instead of approved.
+allowBuilds:
+  core-js-pure: false


### PR DESCRIPTION
Bumps `packageManager` from `pnpm@10.34.5` to `pnpm@11.22.0` (latest v11).

## Changes

- **`package.json`** — `packageManager: "pnpm@11.22.0"`.
- **`pnpm-workspace.yaml`** (new) — pnpm 11 no longer reads settings from `.npmrc` or `package.json#pnpm`; this is the config file now. It holds one entry, needed because v11 makes `strictDepBuilds: true` the default, which turns ignored dependency build scripts into an **error** instead of a warning. The only offender is `core-js-pure` (`@shufo/prettier-plugin-blade` → `blade-formatter` → `xregexp` → `@babel/runtime-corejs3`), whose postinstall only prints a funding banner — so it's denied rather than approved.
- **`.prettierrc.json`** — the 2-space override matched `**/*.yml` only, so the new `.yaml` file was formatted at 4 spaces; added `**/*.yaml`.

`pnpm-lock.yaml` is unchanged — lockfile format 9.0 carries over — and `pnpm build` produces byte-identical assets in `public/build/`.

## No CI change needed

`pnpm/action-setup` reads `packageManager` from `package.json`, and the pinned SHA is already v6.0.10 (current). Node 24 in the workflow satisfies v11's `node >= 22.13`.

## Notes for reviewers

- **First install purges `node_modules`.** The store index moved to SQLite (store v11), so pnpm recreates the modules dir. Interactively it prompts; without a TTY it aborts with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. GitHub Actions sets `CI` itself so the workflow is fine, but locally you may need `CI=true pnpm install` (or just confirm the prompt). The `cache: 'pnpm'` store cache won't be reused once, for this bump only.
- **`minimumReleaseAge` now defaults to 1440 minutes.** Packages published in the last 24h won't resolve, so a Renovate PR bumping to a just-published version may fail to update the lockfile until it ages out. Left enabled deliberately — it's the intended supply-chain protection. Set `minimumReleaseAge: 0` in `pnpm-workspace.yaml` if it becomes a nuisance.

Migration guide: https://pnpm.io/11.x/migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
