### PR TITLE
🤖 Add the Claude Code authoring workflow

### DIFF
--- a/.claude/hooks/guard-expected-urls.sh
+++ b/.claude/hooks/guard-expected-urls.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# PreToolUse guard for scripts/expected-urls.txt.
+#
+# That file is the URL-parity invariant made executable: scripts/verify.mjs asserts
+# dist/ contains exactly those 57 pages, and it gates the Cloudflare deploy. Adding a
+# line is routine (a new talk). Removing one silently de-indexes a live URL, which is
+# the one mistake in this repo that no test can catch afterwards — the page is simply
+# gone. So every write here turns into a confirmation prompt instead of an
+# auto-accepted edit.
+set -uo pipefail
+
+path=$(jq -r '.tool_input.file_path // ""' 2>/dev/null) || exit 0
+
+case "$path" in
+    */scripts/expected-urls.txt | scripts/expected-urls.txt) ;;
+    *) exit 0 ;;
+esac
+
+read -r -d '' reason <<'TXT' || true
+scripts/expected-urls.txt is the URL-parity guard. All 57 entries are indexed and must
+keep resolving without a redirect; scripts/verify.mjs asserts dist/ against this list
+and gates the deploy.
+
+ADDING a line is routine — a new talk needs one.
+REMOVING or renaming one takes a live URL off the site. That is a deliberate SEO
+decision, never a cleanup. Confirm it is intended before allowing this edit.
+TXT
+
+jq -n --arg r "$reason" \
+    '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"ask",permissionDecisionReason:$r}}'

--- a/.claude/hooks/verify-build.sh
+++ b/.claude/hooks/verify-build.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Stop hook: rebuild and re-run the verify.mjs assertions whenever a turn changed
+# something that ends up in dist/.
+#
+# scripts/verify.mjs is a deploy gate — it runs in CI and inside the Cloudflare build
+# command, so a regression that slips out of a turn becomes a red build on main.
+#
+# Configured with asyncRewake, so this costs the turn nothing: it runs in the
+# background and only wakes the model on exit 2. Measured on this repo: ~14s warm,
+# ~45s when dist/ is absent and all 879 image variants have to be written.
+#
+# Deliberately silent on success. It fires on every stop, and a turn that only
+# answered a question should leave no trace.
+set -uo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd) || exit 0
+cd "$repo" || exit 0
+
+payload=$(cat 2>/dev/null || true)
+session=$(printf '%s' "$payload" | jq -r '.session_id // "unknown"' 2>/dev/null || echo unknown)
+
+cache="$repo/node_modules/.cache/tap-verify"
+mkdir -p "$cache" 2>/dev/null || exit 0
+stamp_file="$cache/stamp"
+blocks_file="$cache/blocks-$session"
+lock="$cache/lock"
+
+# Anything that can change dist/. package.json and pnpm-lock.yaml are in because a
+# dependency bump changes the emitted CSS and JS.
+watch=(src astro.config.mjs public wrangler.jsonc scripts package.json pnpm-lock.yaml)
+
+# Fingerprint = committed state + uncommitted state. HEAD alone would miss a dirty
+# tree; porcelain alone would miss a turn that ended in a commit, which is exactly the
+# turn most worth verifying.
+fingerprint=$(
+    printf '%s\n' "$(git rev-parse HEAD 2>/dev/null || echo nohead)"
+    git status --porcelain -- "${watch[@]}" 2>/dev/null
+    git diff --stat HEAD -- "${watch[@]}" 2>/dev/null
+)
+fingerprint=$(printf '%s' "$fingerprint" | shasum -a 256 | cut -d' ' -f1)
+
+[ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$fingerprint" ] && exit 0
+
+# Async means a later stop can fire while this one is still building. Two concurrent
+# `astro build` runs would race over dist/, so the second one just yields — its state
+# is a superset and the next stop re-checks anyway.
+mkdir "$lock" 2>/dev/null || exit 0
+trap 'rmdir "$lock" 2>/dev/null' EXIT
+
+pnpm_bin=$(command -v pnpm 2>/dev/null || true)
+if [ -z "$pnpm_bin" ]; then
+    # nvm-managed installs are absent from a stripped PATH; take the newest.
+    pnpm_bin=$(ls -t "$HOME"/Library/Application\ Support/Herd/config/nvm/versions/node/*/bin/pnpm 2>/dev/null | head -1)
+fi
+if [ -z "$pnpm_bin" ]; then
+    echo "Stop hook skipped: pnpm not found on PATH, so build + verify did not run." >&2
+    exit 0
+fi
+
+if ! out=$("$pnpm_bin" --silent build 2>&1); then
+    step="pnpm build"
+elif ! out=$("$pnpm_bin" --silent verify 2>&1); then
+    step="pnpm verify"
+else
+    printf '%s' "$fingerprint" >"$stamp_file"
+    rm -f "$blocks_file"
+    exit 0
+fi
+
+# Surface the failing lines, not just the tail: verify.mjs prints ~37 passing "✓"
+# lines, so a plain tail shows the summary and hides the assertion that broke.
+tail_out=$(printf '%s' "$out" | grep -E '✗|FAIL|^ *Error|error( TS[0-9]+)?:' | head -30)
+[ -z "$tail_out" ] && tail_out=$(printf '%s' "$out" | tail -40)
+
+# Loop guard: if two consecutive stops in this session could not get the build green,
+# stop waking the model and hand it to the user rather than spinning.
+blocks=$(cat "$blocks_file" 2>/dev/null || echo 0)
+if [ "$blocks" -ge 2 ]; then
+    rm -f "$blocks_file"
+    echo "Stop hook: $step is still failing after two attempts — not re-waking." >&2
+    printf '%s\n' "$tail_out" >&2
+    exit 0
+fi
+printf '%s' "$((blocks + 1))" >"$blocks_file"
+
+cat >&2 <<MSG
+$step failed, so dist/ is not deploy-clean. scripts/verify.mjs gates the Cloudflare
+build, so this would go red on main. Fix it, or tell the user plainly what is broken
+and why you are leaving it.
+
+Failures:
+$tail_out
+MSG
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-expected-urls.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/verify-build.sh\"",
+            "asyncRewake": true,
+            "timeout": 300,
+            "statusMessage": "Rebuilding and verifying dist/"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/add-talk/SKILL.md
+++ b/.claude/skills/add-talk/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: add-talk
+description: Add a new Talk am Pegel event as an MDX content entry — frontmatter, co-located images, speaker references, and the expected-urls.txt line. Use when a new talk is announced.
+disable-model-invocation: true
+---
+
+# Add a talk
+
+This repository **is** the CMS. Adding a talk means adding one directory and opening a
+pull request; Cloudflare gives the PR a preview URL, and merging to `main` deploys it.
+
+**The directory name is the URL slug.** `src/content/talks/<slug>/index.mdx` publishes at
+`/talks/<slug>`. There is no separate routing table and no way to change the URL later
+without losing the indexed page, so choose the slug once and deliberately.
+
+## 1. Gather what the schema requires
+
+Every field below is **required** — `src/content.config.ts` has no defaults for them, and
+a missing one fails `astro check` rather than rendering blank. Ask the user for anything
+not supplied; do not invent values.
+
+| Field | Notes |
+| --- | --- |
+| `title` | The talk's own title, without the "Talk am Pegel #N" prefix |
+| `textline` | The kicker, `"Talk am Pegel #12"` — quote it, the `#` starts a YAML comment |
+| `date` | Start datetime **with an explicit Europe/Berlin offset** (see step 2) |
+| `locationName` | `Pegelbar` for the usual venue |
+| `eventbriteUrl` | Must be a real URL — see the constraint below |
+| `mainImage` | Relative path to a co-located image, `./name.jpg` |
+| `attendants` | Person slugs, in the order they should appear |
+
+Optional: `isVirtual` (default `false`), `locationUrl` (default `""`), `location`
+(the geo block — **omit it entirely for a virtual event**, which is what the three
+virtual talks do).
+
+> **`eventbriteUrl` has no optional form.** The schema is `z.url()`, so you cannot create
+> a talk entry before the Eventbrite listing exists. If the user needs to publish an
+> announcement first, say so and offer the real fix — make it `optionalUrl` in
+> `src/content.config.ts` and guard the CTA in `src/pages/talks/[slug].astro` — rather
+> than committing a placeholder URL that would ship as a live broken button.
+
+## 2. Get the date offset right
+
+A bare local datetime is parsed in the **build machine's** timezone, which is UTC on
+CI — shifting every displayed time and the Event JSON-LD `startDate`. Always write the
+offset. Germany switches, so it is `+01:00` in winter and `+02:00` in summer:
+
+```bash
+node -e 'const s=process.argv[1];const p=new Intl.DateTimeFormat("en",{timeZone:"Europe/Berlin",timeZoneName:"longOffset"}).formatToParts(new Date(s+"T12:00:00Z"));console.log(p.find(x=>x.type==="timeZoneName").value.replace("GMT",""))' 2027-03-29
+# => +02:00
+```
+
+Kirby got this wrong — it emitted a fixed `+0100` for all 11 talks, so 6 of them
+advertised the wrong start time for years. Do not reintroduce it.
+
+## 3. Check the speakers exist
+
+`attendants` uses `reference('persons')`, so each entry must be an existing directory
+name under `src/content/persons/`:
+
+```bash
+ls src/content/persons/ | grep -i <surname>
+```
+
+A speaker who is not there yet needs their own entry **first**, or the build fails with
+an unresolved reference:
+
+```
+src/content/persons/<slug>/index.mdx      # title, subHeading, website/linkedin/xing ("" if unused), mainImage
+src/content/persons/<slug>/<portrait>.jpg
+```
+A person entry has **no body** — frontmatter only (see any existing one). `mainImage` is
+the one optional field; two persons have none and fall back to rendered initials. A new
+person publishes at `/persons/<slug>`, so it needs its **own** `expected-urls.txt` line
+as well as the talk's.
+
+## 4. Create the directory
+
+Copy `template/index.mdx` from this skill and fill it in. Images go **next to** the MDX
+file, not in `public/` — they must be `import`ed so Astro can optimize them, and
+`public/` is unprocessed passthrough.
+
+Downscale anything huge on the way in; nothing renders above 1800px and the repo already
+carries the cost of one 7.2MB PNG:
+
+```bash
+# long edge capped at 2400, matching what the importer did
+sips -Z 2400 ~/Downloads/photo.jpg --out src/content/talks/<slug>/photo.jpg
+```
+
+**Body conventions**, in the order they matter:
+
+- Headings are `##` (`###` for a sub-heading). Nothing uses `#` — the page title is the
+  hero.
+- Prose can be plain Markdown paragraphs. Existing entries carry verbatim `<p>` tags
+  because the importer preserved Kirby's HTML; both render identically, so use Markdown
+  in a new file and leave existing files alone rather than reformatting them.
+- **GFM and smart punctuation are off.** Bare URLs are not autolinked, and quotes are not
+  converted — type the German typographic quotes („…“) literally.
+- Images use `<Figure src={img0} alt="…" caption="…" width="md" />`, and galleries
+  `<Gallery images={[img1, img2, …]} />`. Both need an explicit `import` at the top of the
+  body, and **image import numbers are per entry** — always start at `img0` in a new
+  file. They are not globally unique, and making them so caused churn across seven
+  unrelated talks once already.
+- A blockquote must be **one single line** of explicit HTML:
+  `<blockquote><p>…</p><footer>…</footer></blockquote>`. Split across lines, MDX wraps the
+  text in a `<p>` and puts `<footer>` inside it — invalid nesting that `verify.mjs`
+  fails on. This is also why `src/content/` is in `.prettierignore`; do not run Prettier
+  over it.
+
+## 5. Register the URL
+
+Add `/talks/<slug>` to `scripts/expected-urls.txt`, plus a `/persons/<slug>` line for each
+newly created person. Keep the file sorted (`LC_ALL=C`); `verify.mjs` compares as a set,
+so order is cosmetic but the file stays readable.
+
+Editing that file prompts for confirmation — a hook guards it, because removing a line
+silently de-indexes a live page. Adding one is exactly what it expects.
+
+## 6. Verify
+
+```bash
+pnpm check && pnpm build && pnpm verify
+```
+
+`verify.mjs` must report **PASS** with the check count risen by one (it counts the URL
+inventory as a single assertion, so watch for `all N Kirby URLs built, none extra`
+reflecting the new total). Then look at the page:
+
+```bash
+pnpm dev   # http://localhost:4321/talks/<slug>
+```
+
+A **future-dated** talk renders the Eventbrite signup card and the two-column layout;
+a past-dated one renders full-width prose with no CTA. That branch is decided at build
+time, so if you are adding an upcoming talk you are exercising code that is otherwise
+dead — confirm the card, the ticket icon and the `fathom.trackGoal` button all appear.
+
+## 7. Ship it
+
+Open a pull request. Cloudflare attaches a preview URL; check the new page and `/talks`
+there before merging. Merging to `main` deploys.

--- a/.claude/skills/add-talk/template/index.mdx
+++ b/.claude/skills/add-talk/template/index.mdx
@@ -1,0 +1,46 @@
+---
+# Copy to src/content/talks/<slug>/index.mdx — the directory name becomes the URL.
+# Every field down to `attendants` is required; the build fails without it.
+title: REPLACE — the talk title, without the "Talk am Pegel #N" prefix
+textline: "Talk am Pegel #REPLACE" # quoted: an unquoted # starts a YAML comment
+# Explicit Europe/Berlin offset. +01:00 in winter, +02:00 in summer — compute it,
+# don't guess; see step 2 of the skill.
+date: 2027-01-01T19:00:00+01:00
+isVirtual: false
+locationName: Pegelbar
+locationUrl: ""
+eventbriteUrl: REPLACE — must be a real URL, the schema rejects anything else
+mainImage: ./REPLACE.jpg
+attendants:
+  - REPLACE-person-slug
+  - joerg-geerlings # the host, last in every existing talk
+# The venue block, copied verbatim from any Pegelbar talk. DELETE the whole `location`
+# key for a virtual event — that is what the three virtual talks do.
+location:
+  lat: 51.1996335
+  lon: 6.6958312
+  address: Am Zollhafen
+  number: "5"
+  postcode: "41460"
+  city: Neuss
+  region: Nordrhein-Westfalen
+  country: Deutschland
+  countryCode: de
+---
+
+REPLACE — the announcement text, as plain Markdown paragraphs. Type German quotes
+(„so“) literally; smart punctuation is switched off.
+
+{/* Delete this comment and the imports below if the body has no images.
+    Imports are numbered PER ENTRY — always start at img0 in a new file.
+
+import Figure from '../../../components/blocks/Figure.astro';
+import Gallery from '../../../components/blocks/Gallery.astro';
+import img0 from './REPLACE.jpg';
+
+<Figure src={img0} alt="REPLACE" caption="REPLACE, or drop the attribute" width="md" />
+<Gallery images={[img0]} />
+
+A blockquote must stay on ONE line, or <footer> ends up inside a <p>:
+<blockquote><p>REPLACE quote.</p><footer>REPLACE attribution</footer></blockquote>
+*/}

--- a/.claude/skills/recap-talk/SKILL.md
+++ b/.claude/skills/recap-talk/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: recap-talk
+description: Turn a past Talk am Pegel entry from an announcement into a post-event report — add the recap photos and gallery, rewrite the body, and drop the stale Eventbrite CTA. Use after an event has happened.
+disable-model-invocation: true
+---
+
+# Recap a talk after it happened
+
+An event's page is written twice. Before the talk it announces it and sells tickets;
+afterwards it becomes the report of what was said. This is the second pass: same
+directory, same URL, new content.
+
+Two entries in the repo are worked examples — read one before starting:
+
+- `src/content/talks/talk-am-pegel-9-jetzt-durchstarten-deutschland-im-wettbewerb/` —
+  the full shape: `##` heading, a captioned lead photo, the report, then a nine-image
+  gallery.
+- `src/content/talks/talk-am-pegel-11-sicherheit-als-standortfaktor/` — the minimal
+  shape: heading, one photo, the report, a photo-credit line.
+
+## Nothing about the URL changes
+
+The slug, the directory and `/talks/<slug>` all stay as they are. **Do not touch
+`scripts/expected-urls.txt`** — the page count is unchanged, and there is nothing to
+add. Keep `date` at the real event datetime too; it is the sort key and the JSON-LD
+`startDate`.
+
+## Why this is time-sensitive
+
+`isPast()` is evaluated **at build time**, not per request. There is no scheduled
+rebuild — Cloudflare Workers Builds deploys on push to `main` and nothing else. So
+between the event happening and this recap being merged, the live page still shows the
+"Anmeldung" card and a **Ticket sichern** button for a talk that is over.
+
+Shipping the recap is what removes it. Mention that to the user if the event was a while
+ago.
+
+## 1. Collect the footage
+
+Photos go **next to** the MDX file, not in `public/` — they have to be `import`ed to be
+optimized, and `public/` is unprocessed passthrough. Downscale on the way in; nothing
+renders above 1800px:
+
+```bash
+cd src/content/talks/<slug>
+for f in ~/Downloads/recap/*.jpg; do sips -Z 2400 "$f" --out "$(basename "$f")"; done
+```
+
+Keep the announcement's `mainImage` unless the user wants a real event photo there
+instead — it is the hero, the OG image and the Event JSON-LD image, so swapping it
+changes what social previews show.
+
+### Video is not supported
+
+There is no video renderer. Kirby's blueprint permitted a `video` block type but no
+entry ever used one, so the port has only `Figure` (single image) and `Gallery`
+(lightbox set). If the recap material includes video, stop and tell the user rather than
+improvising: it needs a new `src/components/blocks/Video.astro`, and for a German site
+an embedded YouTube or Vimeo player also means a `src/content/pages/datenschutz.mdx`
+update, because the embed sets third-party cookies before consent. That is a feature
+decision, not part of a recap.
+
+## 2. Rewrite the body
+
+Replace the announcement prose with the report. The structure that both precedents use:
+
+```mdx
+import Figure from '../../../components/blocks/Figure.astro';
+import Gallery from '../../../components/blocks/Gallery.astro';
+import img0 from './lead-photo.jpg';
+import img1 from './event-1.jpg';
+
+## A heading that says what happened
+
+<Figure src={img0} alt="" caption="v.l.n.r.: Name, Name, Name" width="md" />
+
+Report paragraphs…
+
+<Gallery images={[img1, img2, img3]} />
+
+<p><em>Foto: Credit / source</em></p>
+```
+
+Things that will bite:
+
+- **Image imports are numbered per entry.** Continue from the highest `img` already in
+  *this* file; never renumber the existing ones. The numbers are not globally unique —
+  making them so once renumbered variables across seven unrelated talks.
+- **A blockquote must be one single line**:
+  `<blockquote><p>…</p><footer>…</footer></blockquote>`. Split over several lines, MDX
+  wraps the text in a `<p>` and nests `<footer>` inside it, which `verify.mjs` fails.
+  Speaker quotes in these reports are usually inline in the prose with „…“ instead.
+- **GFM and smart punctuation are off.** Type „…“ literally; bare URLs are not linked.
+- **`src/content/` is in `.prettierignore` on purpose.** Do not format it.
+- `alt` may be `""` for a decorative photo — `verify.mjs` requires the attribute to be
+  present, not non-empty — but write real alt text when the photo carries information.
+
+## 3. Speakers who changed
+
+Talk 11 is the precedent: Papperger cancelled and von Brandenstein stood in. `attendants`
+was left exactly as announced and the substitution was explained in the prose; no person
+entry was created for the stand-in.
+
+Follow that unless the user asks otherwise. Adding a person entry is the alternative, and
+it is a bigger change — a new `/persons/<slug>` URL, which does need an
+`expected-urls.txt` line and shows up in the sitemap. Ask before doing it; don't decide
+silently.
+
+## 4. Verify
+
+```bash
+pnpm check && pnpm build && pnpm verify
+```
+
+`verify.mjs` must still report **PASS**, with the same check count as before — a recap
+adds no pages. The assertions most likely to catch a mistake here are `all <img> have an
+alt attribute`, `no block elements nested inside <p>` (the blockquote trap) and `all
+pages have balanced tags`.
+
+Then look at it:
+
+```bash
+pnpm dev   # http://localhost:4321/talks/<slug>
+```
+
+Confirm the Eventbrite card is **gone** and the prose is full-width, the lead photo
+renders at the `md` width, and each gallery image opens in the BigPicture lightbox on
+click.
+
+## 5. Ship it
+
+Open a pull request; Cloudflare gives it a preview URL. Check the talk page and `/talks`
+there — the timeline card uses `mainImage` and the excerpt comes from the first text
+block, so a rewritten body changes the listing too. Merging to `main` deploys.

--- a/.claude/skills/verify-live/SKILL.md
+++ b/.claude/skills/verify-live/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: verify-live
+description: Sweep the production site (or a PR preview) for URL parity, redirects, cache regimes, security headers and the Cloudflare-owned robots.txt block. Use after a deploy or a Cloudflare settings change.
+disable-model-invocation: true
+---
+
+# Verify the live site
+
+`pnpm verify` proves `dist/` is correct. This proves the **edge serves it correctly** —
+a different question, because everything it checks comes from outside the build:
+`html_handling` in `wrangler.jsonc`, and a set of Cloudflare zone settings that are not
+in this repo at all.
+
+```bash
+scripts/verify-live.sh                                   # production
+scripts/verify-live.sh https://<hash>.talk-am-pegel.workers.dev   # a PR preview
+```
+
+20 checks, read-only, ~30 seconds. Exit 0 on PASS, 1 on FAIL.
+
+## When to run it
+
+- **After a deploy that changed URLs** — a new talk or person. Section 1 is the real
+  check: 57 pages, all 200, none redirecting.
+- **After touching `wrangler.jsonc`** — `routes`, `html_handling` and
+  `not_found_handling` all change edge behaviour invisibly to the build.
+- **After any Cloudflare dashboard change.** This is the main reason the script exists.
+  Four things the repo cannot see live in the zone: the apex→www redirect, HSTS, the
+  security-headers transform, and the managed AI-bot block that Cloudflare *prepends* to
+  `robots.txt`. That last one has silently stopped firing once already, and nothing in
+  CI would have noticed.
+
+## Reading a failure
+
+| Failing section | What it usually means |
+| --- | --- |
+| 1, some URLs 404 | The deploy did not include them, or a slug changed. Compare against `scripts/expected-urls.txt`. |
+| 1, a URL **redirects** | The regression this whole repo is built to prevent. Check `trailingSlash`/`build.format` in `astro.config.mjs` and `html_handling` in `wrangler.jsonc`; all three have to agree. |
+| 2, `/talks` or `/persons` 404 | `dist/` holds both `talks.html` and a `talks/` directory. Resolution order puts the file first — no Cloudflare doc covers the collision, so treat a change here as undocumented behaviour that must be re-established empirically. |
+| 3, no 307 | Canonicalisation is off; `.html` and trailing-slash variants would be indexable duplicates. |
+| 4 | The apex DNS record lost its proxied hostname. It must stay a proxied `A` record for the redirect to attach. |
+| 5, bodyless 404 | `not_found_handling` fell back to its `"none"` default. |
+| 6, HTML cached | Static HTML being cached at the edge means content changes stop appearing. |
+| 7 | A zone setting was switched off. **Do not fix this in `public/_headers`** — the zone wins, and setting a header in both places joins the values with a comma. |
+| 8, no `Content-Signal` | Cloudflare has stopped prepending its managed block. Re-enable the toggle in the dashboard; it is not a repo change. |
+
+## What it deliberately does not check
+
+- **Rendering and interactivity.** Alpine, the BigPicture lightbox, FlyOnUI tooltips and
+  the scroll reveals need a browser. The Playwright MCP server is configured for that.
+- **Anything requiring a non-browser user agent.** Production 403s unusual UAs, so the
+  script presents a Chrome UA. A bare `curl` sweep returns 403 everywhere and reads like
+  a total outage — if you probe by hand, pass `-A`.

--- a/.claude/skills/verify-live/SKILL.md
+++ b/.claude/skills/verify-live/SKILL.md
@@ -18,6 +18,11 @@ scripts/verify-live.sh https://<hash>.talk-am-pegel.workers.dev   # a PR preview
 
 20 checks, read-only, ~30 seconds. Exit 0 on PASS, 1 on FAIL.
 
+Against a `workers.dev` preview it runs 17 and marks 3 as skipped (`-`), because the
+apex redirect, HSTS and the managed `robots.txt` block are zone behaviours and a preview
+hostname is outside the zone. That is expected, not a regression — the script detects the
+host itself, so a preview run should still say PASS.
+
 ## When to run it
 
 - **After a deploy that changed URLs** — a new talk or person. Section 1 is the real

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,14 @@
     "astro-docs": {
       "type": "http",
       "url": "https://mcp.docs.astro.build/mcp"
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest"
+      ],
+      "env": {}
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,20 +15,24 @@ guidance.
 ## Commands
 
 ```bash
-pnpm dev        # Astro dev server, http://localhost:4321
-pnpm build      # -> dist/
-pnpm verify     # assert the output is intact (37 assertions) — also a deploy gate
-pnpm check      # astro check
-pnpm preview    # serve dist/
-pnpm deploy:cf  # build + verify + wrangler deploy
+pnpm dev         # Astro dev server, http://localhost:4321
+pnpm build       # -> dist/
+pnpm verify      # assert dist/ is intact (37 assertions) — also a deploy gate
+pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (20 checks)
+pnpm check       # astro check
+pnpm preview     # serve dist/
+pnpm deploy:cf   # build + verify + wrangler deploy
 ```
 
 `deploy:cf` is namespaced because `pnpm deploy` collides with pnpm's built-in command.
 
 ## Docs
 
-`.mcp.json` registers the **Astro Docs MCP server** (`https://mcp.docs.astro.build/mcp`), which
-serves a live index of the Astro documentation. Prefer it over recalling Astro APIs from memory —
+`.mcp.json` registers two MCP servers at project scope, so both need approving once per
+user. The **Astro Docs MCP server** (`https://mcp.docs.astro.build/mcp`) serves a live index of
+the Astro documentation. **Playwright** (`npx @playwright/mcp@latest`) drives a real browser —
+the only way to check the things static output cannot prove: Alpine initialising, the
+BigPicture lightbox, FlyOnUI tooltips and the scroll reveals. Prefer it over recalling Astro APIs from memory —
 this project runs Astro 7, and several things moved recently: Satteri replaced remark/rehype,
 `compressHTML` defaults to `'jsx'`, `z` moved from `astro:content` to `astro/zod`, and the Fonts
 API became stable. Project-scoped MCP servers need approving once per user.
@@ -39,7 +43,8 @@ All 57 public URLs are indexed and must keep working **without a redirect**. The
 built around this.
 
 - `scripts/expected-urls.txt` is the guard. `scripts/verify.mjs` asserts `dist/` contains exactly
-  those pages. **Removing a line is a deliberate SEO decision, not a cleanup.**
+  those pages. **Removing a line is a deliberate SEO decision, not a cleanup.** A `PreToolUse`
+  hook turns every edit of that file into a confirmation prompt for exactly this reason.
 - URLs are extensionless with no trailing slash. `astro.config.mjs` sets `trailingSlash: 'never'`
   and `build.format: 'file'`; `wrangler.jsonc` sets `html_handling: "drop-trailing-slash"`. Changing
   any of those three requires re-checking every URL.
@@ -109,12 +114,42 @@ change to one talk does not churn others.
 
 ## Verification
 
-`scripts/verify.mjs` is the only verification tooling and it is load-bearing: it runs in CI
-(`.github/workflows/ci.yml`) and as part of the Cloudflare build command, so a failure blocks the
-deploy. `pnpm verify` runs it against `dist/`.
+`scripts/verify.mjs` is load-bearing: it runs in CI (`.github/workflows/ci.yml`) and as part of
+the Cloudflare build command, so a failure blocks the deploy. `pnpm verify` runs it against
+`dist/`.
+
+`scripts/verify-live.sh` is the other half, and answers a different question: not "is `dist/`
+correct" but "does the edge serve it correctly". Everything it checks originates outside the
+build — `html_handling` in `wrangler.jsonc` plus four Cloudflare zone settings that are not in
+this repo (apex→www, HSTS, the security-headers transform, and the managed AI-bot block
+prepended to `robots.txt`). 20 read-only checks, ~30s. Run it after a deploy that changed URLs
+and after any Cloudflare dashboard change. It presents a browser user agent on purpose:
+**production 403s unusual UAs**, so a bare `curl` sweep reads like a total outage.
 
 The migration-era importer and parity harness (`migrate-kirby.mjs`, `parity.mjs`) were deleted with
 the PHP stack; recover them from git history if ever needed.
+
+## Claude Code setup
+
+`.claude/` is committed, so the whole authoring workflow travels with the repo.
+
+**Skills** (`/add-talk`, `/recap-talk`, `/verify-live`) are user-invocable only —
+`disable-model-invocation: true` — because each one either publishes content or hits
+production. They encode the two-pass life of an event page: `/add-talk` writes the
+announcement, `/recap-talk` rewrites it afterwards as a report with the event photos.
+
+**Hooks** (`.claude/settings.json`, scripts in `.claude/hooks/`):
+
+- `PreToolUse` on `Edit|Write` → confirmation prompt when `scripts/expected-urls.txt` is
+  touched. Adding a line is routine; removing one de-indexes a live page and nothing
+  downstream can detect it.
+- `Stop` → `pnpm build && pnpm verify`, but only when the turn changed something that
+  reaches `dist/` (fingerprinted over `HEAD` *and* the working tree, so a turn that ends in
+  a commit still counts). It runs with `asyncRewake`, so it costs the turn nothing and only
+  interrupts on failure. ~14s warm, ~45s when `dist/` is absent.
+
+Both hook scripts are plain bash and safe to run by hand — pipe them the payload shape
+documented in their header comments.
 
 ## Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,9 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   per request. Every talk is currently past, so the Eventbrite branch in `talks/[slug].astro` is
   unreachable — exercise it by temporarily dating a talk into the future before changing that file.
 - **Do not set HSTS in `public/_headers`.** The Cloudflare zone owns it and overrides anything set
-  there. `nosniff` IS set there; its source is ambiguous, so leave it.
+  there — setting a header in both places joins the values with a comma. `nosniff` is different:
+  it survives on a `workers.dev` preview, which is outside the zone, so `public/_headers` is
+  demonstrably its source. Keep it there.
 - **Tailwind also auto-detects sources beyond `@source`.** Deleting the Blade templates shrank the
   CSS by 57 kB (156 kB → 98 kB), because auto-detection had been generating FlyOnUI classes that
   only appeared in them.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "astro preview",
     "check": "astro check",
     "verify": "node scripts/verify.mjs",
+    "verify:live": "bash scripts/verify-live.sh",
     "deploy:cf": "astro build && node scripts/verify.mjs && wrangler deploy"
   },
   "devDependencies": {

--- a/scripts/verify-live.sh
+++ b/scripts/verify-live.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# Post-deploy sweep of the PRODUCTION site.
+#
+# scripts/verify.mjs proves dist/ is correct. This proves the edge serves it correctly,
+# which is a different question: URL handling, redirects, cache regimes and the security
+# headers all come from Cloudflare — `html_handling` in wrangler.jsonc plus zone
+# settings that live outside this repo — and none of it is exercised by a local build.
+#
+# Read-only: GETs and HEADs against public URLs. Safe to run any time.
+#
+#   scripts/verify-live.sh                    # https://www.talk-am-pegel.de
+#   scripts/verify-live.sh <base-url>         # a preview deployment
+set -uo pipefail
+
+BASE=${1:-https://www.talk-am-pegel.de}
+BASE=${BASE%/}
+
+# Production 403s unusual user agents, so a bare curl UA fails every request and looks
+# like a total outage. Present as a browser.
+UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
+CURL=(curl -sS --max-time 20 -A "$UA")
+
+pass=0
+fail=0
+ok() {
+    pass=$((pass + 1))
+    printf '  \033[32m✓\033[0m %s\n' "$1"
+}
+no() {
+    fail=$((fail + 1))
+    printf '  \033[31m✗\033[0m %s\n' "$1"
+}
+
+# status + location in one request, without following redirects
+probe() { "${CURL[@]}" -o /dev/null -w '%{http_code} %{redirect_url}' "$1"; }
+headers() { "${CURL[@]}" -D - -o /dev/null "$1"; }
+
+hdr() { printf '%s' "$2" | tr -d '\r' | grep -i "^$1:" | head -1 | cut -d' ' -f2-; }
+
+echo
+echo "Sweeping $BASE"
+echo
+
+# ---------------------------------------------------------------------------
+echo "1. URL inventory — every indexed page, 200 and no redirect"
+missing=()
+redirected=()
+while read -r p; do
+    read -r code loc <<<"$(probe "$BASE$p")"
+    if [ "$code" != "200" ]; then
+        missing+=("$p -> $code")
+    elif [ -n "$loc" ]; then
+        redirected+=("$p -> $loc")
+    fi
+done < <(grep -v '^#' scripts/expected-urls.txt | sed '/^$/d')
+
+total=$(grep -vc '^#\|^$' scripts/expected-urls.txt)
+if [ ${#missing[@]} -eq 0 ]; then ok "all $total indexed URLs return 200"; else
+    no "${#missing[@]}/$total not 200:"
+    printf '      %s\n' "${missing[@]}"
+fi
+# A redirect on an indexed URL is the specific SEO regression this repo is built around.
+if [ ${#redirected[@]} -eq 0 ]; then ok "no indexed URL redirects"; else
+    no "${#redirected[@]} redirect:"
+    printf '      %s\n' "${redirected[@]}"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "2. Collision cases — a .html file and a directory of the same name"
+# dist/ holds both talks.html and talks/. No Cloudflare doc covers which wins;
+# resolution order puts the file first. Regression here would 404 two hub pages.
+for p in / /talks /persons; do
+    read -r code loc <<<"$(probe "$BASE$p")"
+    [ "$code" = "200" ] && [ -z "$loc" ] && ok "$p -> 200" || no "$p -> $code ${loc:+(-> $loc)}"
+done
+
+# ---------------------------------------------------------------------------
+echo
+echo "3. Canonicalisation — variants redirect to the extensionless URL"
+for variant in /kontakt/ /kontakt.html /talks/talk-am-pegel-11-sicherheit-als-standortfaktor.html; do
+    want=${variant%.html}
+    want=${want%/}
+    read -r code loc <<<"$(probe "$BASE$variant")"
+    case "$code" in
+        30*) [ "${loc%/}" = "$BASE$want" ] && ok "$variant -> $code $loc" || no "$variant -> $code $loc (expected $BASE$want)" ;;
+        *) no "$variant -> $code, expected a 3xx to $BASE$want" ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+echo
+echo "4. Apex redirects to www"
+apex=$(printf '%s' "$BASE" | sed 's#//www\.#//#')
+if [ "$apex" != "$BASE" ]; then
+    read -r code loc <<<"$(probe "$apex")"
+    case "$code" in
+        30*) [ "${loc%/}" = "$BASE" ] && ok "$apex -> $code $loc" || no "$apex -> $code $loc (expected $BASE)" ;;
+        *) no "$apex -> $code, expected a 3xx to $BASE" ;;
+    esac
+else
+    ok "skipped (not a www host)"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "5. 404 handling — status AND a branded body"
+read -r code _ <<<"$(probe "$BASE/definitely-not-a-page-$RANDOM")"
+[ "$code" = "404" ] && ok "unknown path -> 404" || no "unknown path -> $code"
+body=$("${CURL[@]}" "$BASE/definitely-not-a-page-$RANDOM")
+# not_found_handling defaults to "none", which serves a bodyless 404. wrangler.jsonc
+# sets "404-page"; this is the check that it is still in effect.
+printf '%s' "$body" | grep -q 'talk-am-pegel\|Talk am Pegel' && ok "404 serves the branded page, not a bare status" || no "404 body is not the site's error page"
+
+# ---------------------------------------------------------------------------
+echo
+echo "6. Cache regimes — the two must stay different"
+h=$(headers "$BASE/")
+cc=$(hdr cache-control "$h")
+printf '%s' "$cc" | grep -q 'max-age=0' && ok "HTML: $cc" || no "HTML cache-control is '$cc', expected max-age=0"
+
+# Hashed assets are immutable for a year; find a real one rather than guessing a hash.
+asset=$("${CURL[@]}" "$BASE/" | grep -o '/_astro/[A-Za-z0-9._-]*\.css' | head -1)
+if [ -n "$asset" ]; then
+    h=$(headers "$BASE$asset")
+    cc=$(hdr cache-control "$h")
+    printf '%s' "$cc" | grep -q 'immutable' && ok "/_astro/*: $cc" || no "/_astro/* cache-control is '$cc', expected immutable"
+else
+    no "could not find an /_astro/ asset on the homepage to probe"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "7. Security headers (zone-owned — not set by this repo)"
+h=$(headers "$BASE/")
+sts=$(hdr strict-transport-security "$h")
+[ -n "$sts" ] && ok "HSTS: $sts" || no "no Strict-Transport-Security — the zone setting may have been switched off"
+xcto=$(hdr x-content-type-options "$h")
+[ "$xcto" = "nosniff" ] && ok "X-Content-Type-Options: nosniff" || no "X-Content-Type-Options is '$xcto', expected nosniff"
+
+# ---------------------------------------------------------------------------
+echo
+echo "8. robots.txt and sitemap.xml"
+r=$("${CURL[@]}" "$BASE/robots.txt")
+printf '%s' "$r" | grep -qi 'sitemap:.*sitemap\.xml' && ok "robots.txt points at /sitemap.xml" || no "robots.txt has no sitemap line"
+# Cloudflare PREPENDS a managed AI-bot block to the origin file. It has silently stopped
+# doing so once before, and only this check notices.
+printf '%s' "$r" | grep -qi 'Content-Signal' && ok "Cloudflare's managed AI-bot block is being prepended" || no "no Content-Signal in robots.txt — the Cloudflare managed block is missing"
+read -r code _ <<<"$(probe "$BASE/sitemap.xml")"
+locs=$("${CURL[@]}" "$BASE/sitemap.xml" | grep -c '<loc>')
+[ "$code" = "200" ] && ok "/sitemap.xml -> 200 with $locs <loc> entries" || no "/sitemap.xml -> $code"
+[ "$locs" = "$total" ] && ok "sitemap lists all $total URLs" || no "sitemap lists $locs URLs, expected $total"
+# @astrojs/sitemap would emit sitemap-index.xml and change the URL Search Console holds.
+read -r code _ <<<"$(probe "$BASE/sitemap-index.xml")"
+[ "$code" = "404" ] && ok "no sitemap-index.xml (the hand-rolled endpoint is still in use)" || no "sitemap-index.xml -> $code; something replaced the hand-rolled sitemap"
+
+echo
+if [ "$fail" -eq 0 ]; then
+    printf '\033[32mPASS\033[0m — %s checks, 0 failures\n\n' "$pass"
+else
+    printf '\033[31mFAIL\033[0m — %s passed, %s failure(s)\n\n' "$pass" "$fail"
+    exit 1
+fi

--- a/scripts/verify-live.sh
+++ b/scripts/verify-live.sh
@@ -21,6 +21,14 @@ BASE=${BASE%/}
 UA='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
 CURL=(curl -sS --max-time 20 -A "$UA")
 
+# Zone-owned behaviour (apex redirect, HSTS, the managed robots.txt block) only exists
+# on talk-am-pegel.de. A workers.dev preview is outside the zone, so those checks are
+# skipped there rather than reported as regressions.
+case "$BASE" in
+    *.workers.dev) on_zone=0 ;;
+    *) on_zone=1 ;;
+esac
+
 pass=0
 fail=0
 ok() {
@@ -30,6 +38,10 @@ ok() {
 no() {
     fail=$((fail + 1))
     printf '  \033[31m✗\033[0m %s\n' "$1"
+}
+
+skip() {
+    printf '  \033[90m-\033[0m %s\n' "$1"
 }
 
 # status + location in one request, without following redirects
@@ -100,7 +112,7 @@ if [ "$apex" != "$BASE" ]; then
         *) no "$apex -> $code, expected a 3xx to $BASE" ;;
     esac
 else
-    ok "skipped (not a www host)"
+    skip "apex redirect not checked (not a www host)"
 fi
 
 # ---------------------------------------------------------------------------
@@ -132,10 +144,16 @@ fi
 
 # ---------------------------------------------------------------------------
 echo
-echo "7. Security headers (zone-owned — not set by this repo)"
+echo "7. Security headers"
 h=$(headers "$BASE/")
+# HSTS is zone-owned. nosniff is not: it survives on a workers.dev preview, which is
+# outside the zone, so its source is public/_headers.
 sts=$(hdr strict-transport-security "$h")
-[ -n "$sts" ] && ok "HSTS: $sts" || no "no Strict-Transport-Security — the zone setting may have been switched off"
+if [ "$on_zone" = 1 ]; then
+    [ -n "$sts" ] && ok "HSTS: $sts" || no "no Strict-Transport-Security — the zone setting may have been switched off"
+else
+    skip "HSTS not checked (off-zone host)"
+fi
 xcto=$(hdr x-content-type-options "$h")
 [ "$xcto" = "nosniff" ] && ok "X-Content-Type-Options: nosniff" || no "X-Content-Type-Options is '$xcto', expected nosniff"
 
@@ -146,7 +164,11 @@ r=$("${CURL[@]}" "$BASE/robots.txt")
 printf '%s' "$r" | grep -qi 'sitemap:.*sitemap\.xml' && ok "robots.txt points at /sitemap.xml" || no "robots.txt has no sitemap line"
 # Cloudflare PREPENDS a managed AI-bot block to the origin file. It has silently stopped
 # doing so once before, and only this check notices.
-printf '%s' "$r" | grep -qi 'Content-Signal' && ok "Cloudflare's managed AI-bot block is being prepended" || no "no Content-Signal in robots.txt — the Cloudflare managed block is missing"
+if [ "$on_zone" = 1 ]; then
+    printf '%s' "$r" | grep -qi 'Content-Signal' && ok "Cloudflare's managed AI-bot block is being prepended" || no "no Content-Signal in robots.txt — the Cloudflare managed block is missing"
+else
+    skip "managed AI-bot block not checked (off-zone host)"
+fi
 read -r code _ <<<"$(probe "$BASE/sitemap.xml")"
 locs=$("${CURL[@]}" "$BASE/sitemap.xml" | grep -c '<loc>')
 [ "$code" = "200" ] && ok "/sitemap.xml -> 200 with $locs <loc> entries" || no "/sitemap.xml -> $code"


### PR DESCRIPTION
Now that the panel is gone, adding and updating a talk is a repo operation. This commits that workflow so it travels with the repo instead of living in one person's head.

## Skills

All three are user-invocable only (`disable-model-invocation: true`), because each one either publishes content or hits production.

| Skill | What it does |
| --- | --- |
| `/add-talk` | Writes the announcement, with a fill-in `template/index.mdx` |
| `/recap-talk` | Rewrites it afterwards as a post-event report with the photos |
| `/verify-live` | Drives the new production sweep |

`/add-talk` and `/recap-talk` encode the two-pass life of an event page. Between them they cover the things that have actually gone wrong here before: the Europe/Berlin offset (Kirby emitted a fixed `+0100` and had 6 of 11 talks an hour out), per-entry image import numbering (global numbering once renumbered variables across seven unrelated talks), and the single-line blockquote rule (multi-line puts `<footer>` inside a `<p>`, which `verify.mjs` fails on).

`/recap-talk` states plainly that **video has no renderer** — Kirby's blueprint allowed a `video` block but no entry ever used one — so it tells you to stop and ask rather than improvise. It also notes that an embedded player on a German site means a `datenschutz.mdx` change.

## Hooks

- **`PreToolUse`** on `Edit|Write` → confirmation prompt for any write to `scripts/expected-urls.txt`. Adding a line is routine; removing one de-indexes a live page and nothing downstream can detect it.
- **`Stop`** → `pnpm build && pnpm verify`, but only when the turn changed something that reaches `dist/`. Fingerprinted over `HEAD` *and* the working tree, so a turn that ends in a commit still counts. Runs with `asyncRewake` — it measured 14s warm and 46s cold, too much to pay synchronously on every stop, so it now costs the turn nothing and only interrupts on failure.

Both are plain bash and safe to run by hand.

## `scripts/verify-live.sh` (`pnpm verify:live`)

Answers the question `verify.mjs` cannot: not "is `dist/` correct" but "does the edge serve it correctly". Everything it checks originates outside the build — `html_handling` in `wrangler.jsonc` plus four Cloudflare zone settings that are not in this repo (apex→www, HSTS, the security-headers transform, and the managed AI-bot block prepended to `robots.txt`; that last one has silently stopped firing once already).

20 read-only checks, ~30s. It presents a browser user agent on purpose: production 403s unusual agents, so a bare `curl` sweep reads like a total outage.

## Also

Registers the **Playwright MCP** server — the only way to exercise Alpine initialising, the BigPicture lightbox, the FlyOnUI tooltips and the scroll reveals. Project-scoped, so it needs approving once per user.

## Verification

- `astro check` — 0 errors
- `pnpm verify` — 37/37
- `scripts/verify-live.sh` — 20/20 against production
- CSS unchanged at 98 kB, i.e. the new markdown does not leak into Tailwind's source auto-detection
- Both hooks pipe-tested on their success *and* failure paths; the `PreToolUse` one confirmed to actually fire

## One thing worth a look while reviewing

Live HSTS is `max-age=15552000; includeSubDomains` — 180 days, no `preload`. The old shared host sent `max-age=31536000; includeSubDomains; preload`. The sweep passes either way, but that is a real reduction from the pre-cutover value and may not have been intended when the zone toggle was set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)