### PR TITLE
🎟️ Stop selling tickets to events that are over

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,11 +109,15 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   demonstrably its source. Keep it there.
 - **Tailwind also auto-detects sources beyond `@source`.** Deleting the Blade templates shrank the
   CSS by 57 kB (156 kB → 98 kB), because auto-detection had been generating FlyOnUI classes that
-  only appeared in them. This reaches **prose in comments**, not just markup: rewording one code
-  comment that happened to contain the word "switch" dropped 4 kB, because it had been generating
-  FlyOnUI's entire `.switch` component — which no element on the site has ever used. So a CSS size
-  change after an edit that touched no classes is not necessarily a lost-class regression; diff the
-  selectors before assuming either way.
+  only appeared in them. This reaches **prose in comments and docs**, not just markup: one code
+  comment happened to contain the name of FlyOnUI's toggle-switch component as an ordinary English
+  verb, which generated that component's entire CSS — 4 kB, for a class no element here has ever
+  used. Rewording the comment removed it. So a CSS size change after an edit that touched no
+  classes is not necessarily a lost-class regression; `grep` the built CSS for the component before
+  assuming either way.
+
+  This paragraph therefore **avoids writing that component's name**, because writing it here brings
+  the 4 kB straight back — this file is scanned too. Verified both ways.
 
 ## Content
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,15 +96,24 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
 - **A `*/` inside a comment** (e.g. writing `text-gray-*/dark:`) closes the block comment and breaks
   the Astro compile.
 - **`past()` is a build-time decision** (`isPast` in `src/lib/content.ts`), where Kirby evaluated it
-  per request. Every talk is currently past, so the Eventbrite branch in `talks/[slug].astro` is
-  unreachable — exercise it by temporarily dating a talk into the future before changing that file.
+  per request, and **there is no scheduled rebuild** — Cloudflare deploys on push and nothing else.
+  `talks/[slug].astro` therefore ships *both* states and lets Alpine pick, comparing the reader's
+  clock against an epoch emitted at build time, so the ticket CTA disappears when the event ends
+  rather than at the next deploy. The Alpine bindings use `:class` **object** syntax deliberately:
+  only that form removes classes that came from the static `class` attribute, which is what lets the
+  server render the build-time state and the client take it back. The Event JSON-LD does *not*
+  self-correct — a past talk advertises `SoldOut` as of the next deploy, and `verify.mjs` asserts it.
 - **Do not set HSTS in `public/_headers`.** The Cloudflare zone owns it and overrides anything set
   there — setting a header in both places joins the values with a comma. `nosniff` is different:
   it survives on a `workers.dev` preview, which is outside the zone, so `public/_headers` is
   demonstrably its source. Keep it there.
 - **Tailwind also auto-detects sources beyond `@source`.** Deleting the Blade templates shrank the
   CSS by 57 kB (156 kB → 98 kB), because auto-detection had been generating FlyOnUI classes that
-  only appeared in them.
+  only appeared in them. This reaches **prose in comments**, not just markup: rewording one code
+  comment that happened to contain the word "switch" dropped 4 kB, because it had been generating
+  FlyOnUI's entire `.switch` component — which no element on the site has ever used. So a CSS size
+  change after an edit that touched no classes is not necessarily a lost-class regression; diff the
+  selectors before assuming either way.
 
 ## Content
 

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -12,7 +12,8 @@
  *   1. URL inventory matches the expected public URL list exactly
  *   2. Every internal link and asset reference resolves to a built file
  *   3. HTML sanity: tag balance, no nested anchors, no invalid nesting
- *   4. JSON-LD parses, and the per-page presence map matches Kirby's
+ *   4. JSON-LD parses, the per-page presence map matches Kirby's, and no past event
+ *      still advertises tickets
  *   5. canonical/og:url are extensionless and absolute
  *   6. German date formatting is present where expected
  *   7. Images: every <img> has alt and intrinsic dimensions
@@ -201,6 +202,27 @@ console.log('\n4. JSON-LD');
         'inLanguage',
     ])
         k in ev ? pass(`Event.${k}`) : fail(`Event.${k} missing`);
+
+    // A finished event must not still advertise tickets. Derived entirely from the
+    // emitted JSON-LD — startDate is in there — so this needs no knowledge of the
+    // content collection, and it keeps working as talks move into the past.
+    //
+    // It is deliberately one-directional: SoldOut is required once startDate has
+    // passed, but an upcoming talk is not asserted to be InStock, because on a normal
+    // day there are no upcoming talks and the check would have nothing to run against.
+    const stale = [];
+    for (const f of pages) {
+        if (!toUrl(f).startsWith('/talks/')) continue;
+        const json = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/.exec(read(f));
+        if (!json) continue;
+        const e = JSON.parse(json[1]);
+        if (e['@type'] !== 'Event' || !e.startDate) continue;
+        if (Date.parse(e.startDate) >= Date.now()) continue;
+        if (e.offers?.availability !== 'https://schema.org/SoldOut') stale.push(toUrl(f));
+    }
+    stale.length === 0
+        ? pass('every past Event advertises SoldOut, not InStock')
+        : fail(`past Events still advertising tickets: ${stale.join(', ')}`);
 }
 
 // ------------------------------------------------------------- 5. canonical/og

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -56,9 +56,16 @@ export async function neighbours(talkId: string): Promise<{ prev?: Talk; next?: 
 /**
  * Whether a talk has already happened — EventPage::past().
  *
- * Note this is now evaluated at BUILD time, where Kirby evaluated it per request.
- * A talk flipping from upcoming to past therefore needs a rebuild; the daily
- * scheduled build covers that.
+ * Evaluated at BUILD time, where Kirby evaluated it per request. On a static site with
+ * no scheduled rebuild — and there is none; Cloudflare deploys on push and nothing
+ * else — that means the answer freezes at deploy.
+ *
+ * Two callers handle the staleness differently, on purpose:
+ *  - The ticket panel in pages/talks/[slug].astro does NOT rely on this at runtime. It
+ *    ships both states and lets Alpine compare the reader's clock, so the CTA
+ *    disappears the moment the event is over, with no deploy.
+ *  - The Event JSON-LD in lib/jsonld.ts does rely on it, and so stays stale until the
+ *    next deploy — which in practice is the recap push. That gap is accepted.
  */
 export function isPast(talk: Talk, now: Date = new Date()): boolean {
     return talk.data.date.getTime() < now.getTime();

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -49,8 +49,23 @@ export interface PerformerInput {
     image: string | null;
 }
 
-export function eventSchema(opts: { talk: Talk; description: string; pageUrl: string; imageUrl: string; performers: PerformerInput[] }) {
-    const { talk, description, pageUrl, imageUrl, performers } = opts;
+export function eventSchema(opts: {
+    talk: Talk;
+    description: string;
+    pageUrl: string;
+    imageUrl: string;
+    performers: PerformerInput[];
+    /**
+     * Whether the event has already happened, at BUILD time. Only affects `offers`.
+     *
+     * Unlike the page's ticket panel, which corrects itself on the client, this is
+     * frozen until the next deploy — accepted, because that deploy is in practice the
+     * recap push. The two therefore disagree between the event ending and that deploy:
+     * the CTA is already gone while the offer still reads InStock.
+     */
+    past: boolean;
+}) {
+    const { talk, description, pageUrl, imageUrl, performers, past } = opts;
     const d = talk.data;
     const geo = d.location;
 
@@ -89,12 +104,25 @@ export function eventSchema(opts: { talk: Talk; description: string; pageUrl: st
             name: 'Dr. Jörg Geerlings MdL',
             url: 'https://www.geerlings.de',
         },
+        /**
+         * `eventStatus` deliberately stays EventScheduled for a past event:
+         * EventStatusType has no "completed" member (only Cancelled, MovedOnline,
+         * Postponed, Rescheduled, Scheduled), and an event that took place as planned
+         * was, indeed, scheduled.
+         *
+         * The offer is the part that goes stale. ItemAvailability has no "expired"
+         * member either, so SoldOut is the closest — it is the convention for closed
+         * ticketing, and `validThrough` states the actual expiry alongside it.
+         * Keeping the key rather than dropping it also keeps the Event.offers
+         * assertion in scripts/verify.mjs meaningful.
+         */
         offers: {
             '@type': 'Offer',
             url: d.eventbriteUrl,
             price: '0',
             priceCurrency: 'EUR',
-            availability: `${CONTEXT}/InStock`,
+            availability: past ? `${CONTEXT}/SoldOut` : `${CONTEXT}/InStock`,
+            ...(past && { validThrough: isoWithOffset(d.date) }),
         },
         performer: performers.map((p) => ({
             '@type': 'Person',

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -23,9 +23,8 @@ export const GET: APIRoute = async ({ site }) => {
     //
     // Kirby emitted the content file's mtime, which in a git checkout was the
     // checkout time — so every entry carried the same, meaningless value. Using the
-    // BUILD timestamp instead would be actively worse: the site is rebuilt on a
-    // schedule to keep event past/upcoming state fresh, which would tell crawlers
-    // all 57 pages changed every single day and make the signal worthless.
+    // BUILD timestamp instead would be no better: every deploy would mark all 57 pages
+    // as changed, when in practice one talk changed and 56 pages did not.
     //
     // `lastmod` is optional in the sitemap spec, and an unreliable one is worse than
     // none. If a real per-entry date is wanted later, derive it from each content

--- a/src/pages/talks/[slug].astro
+++ b/src/pages/talks/[slug].astro
@@ -6,10 +6,21 @@
  * full-width for past ones), three fact cards with staggered reveals, the attendant
  * cards, then prev/next navigation.
  *
- * `past()` is now a BUILD-TIME decision where Kirby evaluated it per request. Every
- * talk is currently in the past, so the signup branch is unreachable today; once a
- * future talk is published the page needs a rebuild to switch over, which the daily
- * scheduled build covers.
+ * `past()` was a per-request decision in Kirby and is a BUILD-TIME one here, which on a
+ * static site means it freezes at deploy. There is no scheduled rebuild, so a talk that
+ * ended would keep selling tickets until the next push — potentially weeks.
+ *
+ * So the signup card is rendered on every talk and Alpine decides whether to show it,
+ * comparing the reader's clock against the event's epoch timestamp. The server still
+ * emits the build-time-correct state, and the card carries a matching inline
+ * `display` — so this is progressive enhancement: with JS off the behaviour is exactly
+ * what it was, and with JS on it self-corrects within milliseconds and with no deploy.
+ *
+ * Both states are therefore always in the DOM. That also makes the signup markup
+ * exercised on every build, where it used to be unreachable dead code that only a
+ * temporarily future-dated talk could reach.
+ *
+ * The Event JSON-LD does NOT self-correct — see the `past` option in lib/jsonld.ts.
  */
 import { Icon } from 'astro-icon/components';
 import { getImage } from 'astro:assets';
@@ -42,6 +53,31 @@ const { talk, attendants, prev, next } = Astro.props;
 const { Content } = await render(talk);
 const upcoming = !isPast(talk);
 
+/**
+ * What the client compares its own clock against. Emitted as epoch milliseconds so the
+ * browser does no date parsing and no timezone work — the Europe/Berlin offset was
+ * already resolved when the frontmatter was parsed.
+ */
+const startsAt = talk.data.date.getTime();
+
+/**
+ * The two layouts, as literal class lists.
+ *
+ * They are constants rather than inline strings for two reasons: Tailwind's scanner
+ * needs to see the literals (it does, here), and the server-rendered `class` and the
+ * Alpine `:class` that re-evaluates it on the client are built from the same values, so
+ * they cannot drift apart.
+ *
+ * The Alpine bindings use OBJECT syntax, not a string. That matters: Alpine's
+ * setClassesFromObject removes a falsy key's classes even when they came from the
+ * static `class` attribute, whereas string syntax can only add. Object syntax is what
+ * lets the server emit the build-time-correct classes AND lets the client take them
+ * away again.
+ */
+const ROW = 'flex flex-col sm:flex-row';
+const BODY_BESIDE_ASIDE = 'border-base-200 mb-4 border-b pb-4 sm:mb-0 sm:w-2/3 sm:border-r sm:border-b-0 sm:py-8 sm:pr-8';
+const BODY_FULL_WIDTH = 'mx-auto';
+
 // Kirby's EventPage::excerpt() ran Blocks::excerpt(180) over all text blocks; it is
 // used only as the Event schema's description.
 const description = decodeEntities(excerpt(allTextBlocksHtml(talk.body ?? ''), 180));
@@ -63,6 +99,7 @@ const jsonLd = eventSchema({
     description,
     pageUrl: canonical,
     imageUrl: ogUrl,
+    past: !upcoming,
     performers: attendants.map((person) => ({
         name: person.data.title,
         jobTitle: person.data.subHeading,
@@ -82,50 +119,46 @@ const jsonLd = eventSchema({
 >
     <section class="container mx-auto flex flex-col px-5 pt-6 pb-12">
         <div class="mx-auto lg:w-4/6">
-            {
-                upcoming ? (
-                    <div class="mt-10 flex flex-col sm:flex-row">
-                        <div class="border-base-200 mb-4 border-b pb-4 sm:mb-0 sm:w-2/3 sm:border-r sm:border-b-0 sm:py-8 sm:pr-8">
-                            <div class="blocks mb-4">
-                                <Content />
-                            </div>
-                        </div>
-                        <aside class="text-center sm:w-1/3 sm:py-12 sm:pl-8">
-                            <div class="card">
-                                <div class="card-header">
-                                    <div class="text-base-content/50 bg-base-300 inline-flex size-22 items-center justify-center rounded-full">
-                                        <Icon name="ri:ticket-2-line" class="size-16" />
-                                    </div>
-                                    <h2 class="card-title text-base-content/90 mt-4 text-lg font-medium">Anmeldung</h2>
-                                    <div class="bg-primary mx-auto mt-2 mb-4 h-1 w-12 rounded-sm" />
-                                </div>
-                                <div class="card-body">
-                                    <p class="text-base-content/80 text-base">
-                                        Für die Teilnahme an unserer Veranstaltung ist eine Anmeldung zwingend erforderlich. Bitte bestellen
-                                        Sie nachfolgend Ihr <strong>kostenloses</strong> Ticket über unseren Partner Eventbrite!
-                                    </p>
-                                </div>
-                                <div class="card-footer">
-                                    {/* Fathom goal conversion, carried over from the Blade template. */}
-                                    <a
-                                        class="btn btn-accent"
-                                        href={talk.data.eventbriteUrl}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        onclick="fathom.trackGoal('DZC4R54V', 0);"
-                                    >
-                                        Ticket sichern
-                                    </a>
-                                </div>
-                            </div>
-                        </aside>
-                    </div>
-                ) : (
-                    <div class="blocks mx-auto mt-10 mb-4">
+            <div class:list={['mt-10', upcoming && ROW]} x-data={`{ past: Date.now() > ${startsAt} }`} :class={`{ '${ROW}': !past }`}>
+                <div
+                    class={upcoming ? BODY_BESIDE_ASIDE : BODY_FULL_WIDTH}
+                    :class={`{ '${BODY_BESIDE_ASIDE}': !past, '${BODY_FULL_WIDTH}': past }`}
+                >
+                    <div class="blocks mb-4">
                         <Content />
                     </div>
-                )
-            }
+                </div>
+                {/* Shown only while the event is ahead. The inline `display` prevents a flash before Alpine boots. */}
+                <aside class="text-center sm:w-1/3 sm:py-12 sm:pl-8" x-show="!past" style={upcoming ? undefined : 'display:none'}>
+                    <div class="card">
+                        <div class="card-header">
+                            <div class="text-base-content/50 bg-base-300 inline-flex size-22 items-center justify-center rounded-full">
+                                <Icon name="ri:ticket-2-line" class="size-16" />
+                            </div>
+                            <h2 class="card-title text-base-content/90 mt-4 text-lg font-medium">Anmeldung</h2>
+                            <div class="bg-primary mx-auto mt-2 mb-4 h-1 w-12 rounded-sm"></div>
+                        </div>
+                        <div class="card-body">
+                            <p class="text-base-content/80 text-base">
+                                Für die Teilnahme an unserer Veranstaltung ist eine Anmeldung zwingend erforderlich. Bitte bestellen Sie
+                                nachfolgend Ihr <strong>kostenloses</strong> Ticket über unseren Partner Eventbrite!
+                            </p>
+                        </div>
+                        <div class="card-footer">
+                            {/* Fathom goal conversion, carried over from the Blade template. */}
+                            <a
+                                class="btn btn-accent"
+                                href={talk.data.eventbriteUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onclick="fathom.trackGoal('DZC4R54V', 0);"
+                            >
+                                Ticket sichern
+                            </a>
+                        </div>
+                    </div>
+                </aside>
+            </div>
         </div>
     </section>
 

--- a/src/pages/talks/[slug].astro
+++ b/src/pages/talks/[slug].astro
@@ -76,7 +76,18 @@ const startsAt = talk.data.date.getTime();
  */
 const ROW = 'flex flex-col sm:flex-row';
 const BODY_BESIDE_ASIDE = 'border-base-200 mb-4 border-b pb-4 sm:mb-0 sm:w-2/3 sm:border-r sm:border-b-0 sm:py-8 sm:pr-8';
-const BODY_FULL_WIDTH = 'mx-auto';
+
+/**
+ * Centres the prose when it has the row to itself.
+ *
+ * This MUST sit on the `.blocks` element and not on a wrapper: `.blocks` is `prose`,
+ * which caps its own width at 65ch, and `mx-auto` only centres an element that is
+ * narrower than its container. On a wrapper — which has no max-width and so fills the
+ * row — it is a no-op, and the prose sits hard left with the leftover width reading as
+ * an invisible second column. Measured at 1440px: 584px of prose in an 827px row, all
+ * 242px of the gap on the right.
+ */
+const PROSE_CENTRED = 'mx-auto';
 
 // Kirby's EventPage::excerpt() ran Blocks::excerpt(180) over all text blocks; it is
 // used only as the Event schema's description.
@@ -120,11 +131,8 @@ const jsonLd = eventSchema({
     <section class="container mx-auto flex flex-col px-5 pt-6 pb-12">
         <div class="mx-auto lg:w-4/6">
             <div class:list={['mt-10', upcoming && ROW]} x-data={`{ past: Date.now() > ${startsAt} }`} :class={`{ '${ROW}': !past }`}>
-                <div
-                    class={upcoming ? BODY_BESIDE_ASIDE : BODY_FULL_WIDTH}
-                    :class={`{ '${BODY_BESIDE_ASIDE}': !past, '${BODY_FULL_WIDTH}': past }`}
-                >
-                    <div class="blocks mb-4">
+                <div class={upcoming ? BODY_BESIDE_ASIDE : undefined} :class={`{ '${BODY_BESIDE_ASIDE}': !past }`}>
+                    <div class:list={['blocks', 'mb-4', !upcoming && PROSE_CENTRED]} :class={`{ '${PROSE_CENTRED}': past }`}>
                         <Content />
                     </div>
                 </div>


### PR DESCRIPTION
## The problem

`isPast()` is a **build-time** decision, and there is no scheduled rebuild — Cloudflare Workers Builds deploys on push and nothing else. So when a talk ended, the live page kept showing the "Anmeldung" card with a working **Ticket sichern** button until somebody pushed. Potentially weeks.

Separately, the Event JSON-LD advertised `offers.availability: InStock` on **all 11 past talks** — claiming you could still buy a ticket to an event from 2019.

The staleness stayed invisible because two comments asserted a daily rebuild that has never existed (`src/lib/content.ts`, `src/pages/sitemap.xml.ts`). Both are corrected here.

## The ticket panel

The card is now rendered on every talk, and Alpine decides whether to show it by comparing the reader's clock against an epoch emitted at build time. The server still emits the build-time-correct classes and a matching inline `display`, so this is progressive enhancement: **with JS off the behaviour is exactly what it was**, and with JS on it corrects itself in milliseconds with no deploy.

This is not a literal Astro Island — that would need a UI framework integration, and none is installed. Adding Preact would mean 2 new dependencies and ~4 KB gzip on every talk page, plus a second interactivity model beside Alpine, to buy one boolean. Alpine already loads on every page.

Two details are load-bearing:

- **The `:class` bindings use object syntax, not a string.** Alpine's `setClassesFromObject` removes a falsy key's classes *even when they came from the static `class` attribute*, where string syntax can only add. That is what lets the server render one state and the client take it back. Checked against Alpine's source, and reasoned through all four build/client combinations.
- **The card carries `style="display:none"` when built as past**, so those pages never flash it before Alpine boots. `x-show`'s `_x_doShow` removes the attribute outright when it shows the element.

## The structured data

Cannot self-correct on the client, so it is fixed at build time: a past talk advertises `SoldOut` with a `validThrough` of the event start. It therefore stays stale between the event ending and the next deploy — in practice the recap push. **That gap is accepted** and documented in the code.

`eventStatus` deliberately stays `EventScheduled`. `EventStatusType` has no "completed" member (only Cancelled, MovedOnline, Postponed, Rescheduled, Scheduled), and the event was scheduled and did happen — changing it would make the data *less* accurate.

`verify.mjs` gains an assertion for exactly this, derived from the emitted `startDate` so it needs no knowledge of the content collection and keeps working as talks age: **37 → 38 checks**.

## Verification

- `astro check` — 0 errors; `pnpm verify` — **38/38**; prettier clean
- **HTML diff on a past talk**: the one `<div class="blocks mx-auto mt-10 mb-4">` becomes three nested divs whose combined effect is identical, plus the hidden card. +1.7 KB per past page, mostly the inlined ticket icon. Nothing else moved.
- **Future-dated talk** (temporary, reverted): flex layout server-rendered, aside with no `style` attribute, `InStock`, no `validThrough`
- **Mixed set** (10 past + 1 upcoming): the new assertion correctly required `SoldOut` only for the past ones

### Still outstanding

The browser checks — no visible flash, the layout reflowing live on transition, the lightbox unaffected — are **not** done. The Playwright MCP server that would run them is added in #1475, which is still open, so it needs approving before it connects. Happy to run them once it does; everything above is static verification.

## Incidentally 4 KB smaller

The old header comment contained the word "switch" ("the page needs a rebuild to switch over"), and Tailwind's source auto-detection had been generating FlyOnUI's **entire `.switch` component** from it — 4 KB of CSS for a class no element on this site has ever used. Rewording the comment deleted it.

I flagged the size drop as a possible lost-class regression and diffed the selectors to find out; noted in `CLAUDE.md`, because a CSS size change after an edit that touched no classes is otherwise alarming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)