### PR TITLE
🎨 Scope Tailwind's source detection to src/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,17 +107,23 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   there — setting a header in both places joins the values with a comma. `nosniff` is different:
   it survives on a `workers.dev` preview, which is outside the zone, so `public/_headers` is
   demonstrably its source. Keep it there.
-- **Tailwind also auto-detects sources beyond `@source`.** Deleting the Blade templates shrank the
-  CSS by 57 kB (156 kB → 98 kB), because auto-detection had been generating FlyOnUI classes that
-  only appeared in them. This reaches **prose in comments and docs**, not just markup: one code
-  comment happened to contain the name of FlyOnUI's toggle-switch component as an ordinary English
-  verb, which generated that component's entire CSS — 4 kB, for a class no element here has ever
-  used. Rewording the comment removed it. So a CSS size change after an edit that touched no
-  classes is not necessarily a lost-class regression; `grep` the built CSS for the component before
-  assuming either way.
+- **Tailwind scans only `src/`, and that is deliberate.** `src/styles/site.css` imports Tailwind
+  with `source(none)`, which switches off automatic source detection, leaving the single
+  `@source "../**/*.{astro,ts,js,mdx,md}"` as the only supplier of class candidates. So the CSS is
+  a function of the markup and nothing else — **a class written outside `src/` is not generated**.
 
-  This paragraph therefore **avoids writing that component's name**, because writing it here brings
-  the 4 kB straight back — this file is scanned too. Verified both ways.
+  Detection used to scan the whole repo (minus `.gitignore` and `node_modules`), which swept up
+  prose: any English word matching a FlyOnUI component name generated that component's entire CSS.
+  A code comment cost 4 kB for a component no element here has ever used; the CLAUDE.md paragraph
+  documenting that trap then re-added the same 4 kB by naming it; and deleting the Blade templates
+  had earlier dropped 57 kB the same way. Scoping it removed a further 12.5 kB (96.5 kB → 84 kB) of
+  unused FlyOnUI components — `.input`, `.select`, `.table`, `.filter`, `.validate` and friends.
+
+  If you change the scanning again, the check that actually proves it safe is: for every class used
+  in `dist/**/*.html`, assert the emitted CSS carries a rule for it, and diff `getComputedStyle`
+  across the pages before and after. Size alone tells you nothing — a drop is usually dead weight,
+  not a regression. (Note `@apply` resolves from the theme and is unaffected by detection, so
+  `@utility blocks`' `italic` survives even though the standalone `.italic` utility is gone.)
 
 ## Content
 

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import "tailwindcss" source(none);
 @plugin "@tailwindcss/typography";
 @plugin "flyonui" {
   themes: tap --default;
@@ -7,10 +7,14 @@
 @import "./aos.css";
 
 @import "../../node_modules/flyonui/variants.css";
-/* Only the Astro sources. Deliberately does NOT scan site/templates + site/snippets
-   during the Kirby coexistence phase: the reference site is styled by the committed
-   public/build assets, and scanning Blade too would silently supply classes the port
-   has not actually written yet. */
+/* The ONLY source of class candidates.
+   `source(none)` on the import above disables Tailwind's automatic detection, which
+   otherwise scans the whole repo (minus .gitignore and node_modules) — and that swept up
+   prose. Any English word matching a FlyOnUI component name generated that component's
+   entire CSS: a code comment cost 4 kB for a component no element here has ever used,
+   and the CLAUDE.md paragraph documenting that trap re-added the same 4 kB by naming it.
+   Deleting the Blade templates had earlier dropped 57 kB the same way.
+   Scoping detection to src/ makes the CSS a function of the markup and nothing else. */
 @source "../**/*.{astro,ts,js,mdx,md}";
 
 @plugin "flyonui/theme" {


### PR DESCRIPTION
## Why

Tailwind's automatic source detection scanned the whole repo (minus `.gitignore` and `node_modules`), which means it scanned **prose**. Any English word matching a FlyOnUI component name generated that component's entire CSS.

This repo has paid for that three times:

| | Cost |
| --- | --- |
| The Blade templates, deleted during the migration | 57 kB |
| One code comment containing an ordinary English verb | 4 kB |
| The `CLAUDE.md` paragraph documenting that trap, which named the component | 4 kB again |

That third one is the tell: the failure mode is a documentation edit changing the CSS bundle. Careful wording is not a fix.

## What

`source(none)` on the import switches detection off, leaving the existing `@source "../**/*.{astro,ts,js,mdx,md}"` as the only supplier of candidates. The CSS becomes a function of the markup and nothing else.

**Consequence worth knowing:** a class written outside `src/` is no longer generated. Nothing does that today — `public/` holds only binary assets and text files, and `logo.svg` is referenced via `<img src>` with its class living in `Header.astro`.

**96,527 → 84,044 bytes** (−12.5 kB). What went is unused FlyOnUI components — `.input`, `.select`, `.table`, `.filter`, `.validate`, `.stack`, `.is-valid`/`.is-invalid` and friends — plus the standalone `.italic` and `.transform` utilities, which no element uses as a class.

## Verification

Size alone proves nothing — a drop is usually dead weight, but it *could* be a lost class. Two checks stand behind this:

**1. Class coverage.** For every one of the 234 distinct classes used across `dist/**/*.html`, assert the emitted CSS carries a rule for it.

- Before: 4 without a rule
- After: **the same 4, unchanged** — `image-gallery` and `tooltip-toggle` are JS hooks, `not-prose` is a typography marker, and `btn-neutral/80` was already a no-op (FlyOnUI has no opacity modifier for it)
- **Zero classes lost a rule**

**2. Computed-style diff.** `getComputedStyle` over 26 properties for every classed element on 9 pages at 1440/768/390 — **3147 elements. Identical.**

`@apply` resolves from the theme rather than from detected candidates, so `@utility blocks`' `blockquote footer { @apply … italic }` still emits `font-style:italic` — that rule is byte-identical before and after. I verified this rather than assuming it, since it was the one plausible way to lose something real.

**Interactive components** re-checked in a browser: FlyOnUI tooltip shows on hover, the Alpine sticky bar appears on scroll, the BigPicture lightbox opens, `.btn` keeps the theme accent. No console errors.

`astro check` 0 errors, `pnpm verify` 38/38, prettier clean.

### One harness note

The first computed-style run reported 38 differences. All 38 were `opacity`-only on `.aos` elements — the snapshot was sampling mid-fade. Settling the transitions before snapshotting made the runs identical. Recording it because "38 differences" looked alarming and was measurement noise, which is the same class of mistake that produced false failures during the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)