### PR TITLE
✨ Animate navigation with native view transitions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,17 @@ Images go through `Thumbnail.astro`, which wraps Astro's `<Picture>` with four p
 explicit — do **not** add `layout`, which auto-generates a `sizes` that is wrong for the 50vw
 two-column layouts and inflates the width ladder.
 
+**View transitions are native and cross-document** — `@view-transition { navigation: auto }` in
+`site.css`, no `<ClientRouter />` and not a byte of extra JavaScript, so every page still loads
+normally and Alpine/FlyOnUI/BigPicture keep booting once per document. Paired elements are named with
+Astro's `transition:name`, which compiles to a bare `view-transition-name` rule. A name must be
+unique **per document**, and that dictates the scheme: `site-logo` and `hero-image` everywhere;
+`talk-<slug>` on the `/talks` card figure, the home teaser image and the talk detail hero (that page
+overrides `heroName`, so it carries no `hero-image`); `person-<slug>` on the `Person.astro` avatar.
+Person pages keep the generic `hero-image` because the avatar carries their morph instead.
+`PersonAvatarGroup` is deliberately unnamed — the same person recurs across several cards on
+`/talks`, and duplicate names abort the whole transition.
+
 Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`, `x-transition`,
 `x-cloak`); no components are registered. Alpine just needs starting once, which
 `src/scripts/site.ts` does.
@@ -82,7 +93,12 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
 - **`astro check` needs TypeScript 6.x.** TS 7's native compiler does not expose the API it uses.
   The pin is deliberate.
 - **`astro preview` daemonises and binds IPv6 only.** Use `http://localhost:4321`, not `127.0.0.1`;
-  stop it with `astro preview stop`.
+  stop it with `astro preview stop`. It also sends `Cache-Control: no-cache`, and Chrome silently
+  refuses a cross-document view transition on a `no-cache` response — the outgoing `pageswap` fires
+  with a transition, the incoming `pagereveal` gets `null`. **View transitions therefore never appear
+  under `pnpm preview`**, and the site is fine: production serves
+  `public, max-age=0, must-revalidate`, which works. To check them locally, serve `dist/` with a
+  plain static server instead.
 - **Two paths are excluded from Prettier**, both deliberately (`.prettierignore`):
   `Header.astro` and `pages/talks/index.astro`, because `prettier-plugin-astro` corrupts
   `x-intersect.once` inside JSX expression blocks; and `src/content/`, because the generated MDX
@@ -103,6 +119,11 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   only that form removes classes that came from the static `class` attribute, which is what lets the
   server render the build-time state and the client take it back. The Event JSON-LD does *not*
   self-correct — a past talk advertises `SoldOut` as of the next deploy, and `verify.mjs` asserts it.
+- **A view transition snapshots the incoming page before `IntersectionObserver` fires**, so an
+  element inside an `.aos` wrapper is captured at `opacity: 0` and a shared-element morph lands on
+  something invisible. That is why the reveal on the `/talks` cards sits on `.card-body` rather than
+  `.card`, and why `LatestEvent`'s image no longer carries `x-cloak` — both used to hide the very
+  image the morph targets. Keep `transition:name` off anything a reveal can blank out.
 - **Do not set HSTS in `public/_headers`.** The Cloudflare zone owns it and overrides anything set
   there — setting a header in both places joins the values with a comma. `nosniff` is different:
   it survives on a `workers.dev` preview, which is outside the zone, so `public/_headers` is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,9 +121,12 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   self-correct — a past talk advertises `SoldOut` as of the next deploy, and `verify.mjs` asserts it.
 - **A view transition snapshots the incoming page before `IntersectionObserver` fires**, so an
   element inside an `.aos` wrapper is captured at `opacity: 0` and a shared-element morph lands on
-  something invisible. That is why the reveal on the `/talks` cards sits on `.card-body` rather than
-  `.card`, and why `LatestEvent`'s image no longer carries `x-cloak` — both used to hide the very
-  image the morph targets. Keep `transition:name` off anything a reveal can blank out.
+  something invisible. Every reveal therefore sits *beside* a named element, never above it: on
+  `/talks` it is on `.card-body` rather than `.card`, `LatestEvent`'s image has none at all (nor
+  `x-cloak` any more), and `Person.astro` reveals the name and socials rather than the whole
+  `<article>`, so the avatar stays painted. Keep `transition:name` off anything a reveal can blank
+  out — measure it: probe the incoming element's effective opacity at `pagereveal`, not just that
+  the transition fired.
 - **Do not set HSTS in `public/_headers`.** The Cloudflare zone owns it and overrides anything set
   there — setting a header in both places joins the values with a comma. `nosniff` is different:
   it survives on a `workers.dev` preview, which is outside the zone, so `public/_headers` is

--- a/src/components/LatestEvent.astro
+++ b/src/components/LatestEvent.astro
@@ -29,7 +29,7 @@ const href = `/talks/${talk.id}`;
             x-data="{ visible: false }"
             x-intersect="visible = true"
             :class="visible && 'visible'"
-            x-cloak
+            transition:name={`talk-${talk.id}`}
         >
             <Thumbnail image={talk.data.mainImage} preset="wide" class="w-full rounded-sm object-cover object-center" alt="" />
         </div>

--- a/src/components/LatestEvent.astro
+++ b/src/components/LatestEvent.astro
@@ -24,13 +24,12 @@ const href = `/talks/${talk.id}`;
 
 <section class="my-24 flex flex-col space-y-16">
     <article class="container mx-auto grid grid-cols-1 gap-6 px-5 lg:grid-cols-3 xl:grid-cols-5">
-        <div
-            class="aos aos-fade-up lg:order-last lg:row-span-2 xl:col-span-2"
-            x-data="{ visible: false }"
-            x-intersect="visible = true"
-            :class="visible && 'visible'"
-            transition:name={`talk-${talk.id}`}
-        >
+        {
+            /* No .aos here: this image is a view-transition target, and a reveal would hand
+            the morph a transparent element on the way back from the talk page. The text
+            column beside it still fades up. */
+        }
+        <div class="lg:order-last lg:row-span-2 xl:col-span-2" transition:name={`talk-${talk.id}`}>
             <Thumbnail image={talk.data.mainImage} preset="wide" class="w-full rounded-sm object-cover object-center" alt="" />
         </div>
         <div

--- a/src/components/Person.astro
+++ b/src/components/Person.astro
@@ -39,13 +39,13 @@ const socials = [
     <div class="flex h-full flex-col items-center pb-2 text-center">
         {
             mainImage ? (
-                <figure class="avatar w-full">
+                <figure class="avatar w-full" transition:name={`person-${person.id}`}>
                     <div class="size-full rounded-full">
                         <Thumbnail image={mainImage} preset="square" class="size-full" alt="" />
                     </div>
                 </figure>
             ) : (
-                <figure class="avatar avatar-placeholder w-full">
+                <figure class="avatar avatar-placeholder w-full" transition:name={`person-${person.id}`}>
                     <div class="bg-neutral text-neutral-content size-full rounded-full">
                         <span class="text-9xl uppercase" aria-hidden="true">
                             {initials(title)}

--- a/src/components/Person.astro
+++ b/src/components/Person.astro
@@ -30,11 +30,15 @@ const socials = [
 ].filter((s) => s.href);
 ---
 
+{
+    /* The reveal deliberately skips the avatar: it carries a transition:name, and an .aos
+    ancestor would make it transparent at the moment a view transition snapshots this page.
+    One x-data/x-intersect on the article still drives both revealed children. */
+}
 <article
-    class:list={['relative w-full p-4 sm:w-1/2 md:w-1/3 lg:w-1/5', animate && 'aos aos-fade-up']}
+    class="relative w-full p-4 sm:w-1/2 md:w-1/3 lg:w-1/5"
     x-data={animate ? '{ visible: false }' : undefined}
     x-intersect.once={animate ? `setTimeout(function() { visible = true }, ${animationDelay})` : undefined}
-    :class={animate ? "visible && 'visible'" : undefined}
 >
     <div class="flex h-full flex-col items-center pb-2 text-center">
         {
@@ -55,11 +59,11 @@ const socials = [
             )
         }
 
-        <div class="mt-4 w-full">
+        <div class:list={['mt-4 w-full', animate && 'aos aos-fade-up']} :class={animate ? "visible && 'visible'" : undefined}>
             <h2 class="text-base-content/90 text-lg font-medium">{title}</h2>
             <p class="text-base-content/60 mb-4">{subHeading}</p>
         </div>
-        <div class="absolute bottom-0 w-full">
+        <div class:list={['absolute bottom-0 w-full', animate && 'aos aos-fade-up']} :class={animate ? "visible && 'visible'" : undefined}>
             <span class="inline-flex">
                 {
                     socials.map((social) => (

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -22,9 +22,11 @@ interface Props {
     title: string;
     subtitle?: string | null;
     heroImage?: ImageMetadata;
+    /** See Layout.astro — pages with a subject-specific hero override this. */
+    heroName?: string;
 }
 
-const { title, subtitle, heroImage = pegelbar } = Astro.props;
+const { title, subtitle, heroImage = pegelbar, heroName = 'hero-image' } = Astro.props;
 ---
 
 <header class="bg-neutral relative h-svh md:h-auto" x-data="{ scrolledAway: false }">
@@ -46,12 +48,19 @@ const { title, subtitle, heroImage = pegelbar } = Astro.props;
         </a>
     </div>
 
-    <Thumbnail
-        image={heroImage}
-        sizes="100vw"
-        alt=""
-        class="w-full h-full object-cover object-center block opacity-20 inset-0 absolute"
-    />
+    {/* The positioning and opacity moved off the <img> onto this wrapper purely so the
+        view transition has a plain element to name: `transition:name` reaches a
+        component as a data-astro-transition-scope *prop*, which would have to survive
+        Thumbnail's rest spread and <Picture>'s own attribute forwarding to land on the
+        img. Geometry is unchanged — the img still fills an inset-0 box. */}
+    <div class="absolute inset-0 opacity-20" transition:name={heroName}>
+        <Thumbnail
+            image={heroImage}
+            sizes="100vw"
+            alt=""
+            class="w-full h-full object-cover object-center block"
+        />
+    </div>
 
     <div class="h-full flex flex-col justify-around items-center">
         <div
@@ -60,7 +69,7 @@ const { title, subtitle, heroImage = pegelbar } = Astro.props;
             x-intersect:enter="scrolledAway = false"
         >
             <a href="/" class="flex justify-center">
-                <Logo role="img" aria-label="Talk am Pegel" />
+                <Logo role="img" aria-label="Talk am Pegel" transition:name="site-logo" />
             </a>
         </div>
         <div

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -25,9 +25,16 @@ interface Props extends SeoProps {
     heroTitle?: string;
     heroSubtitle?: string | null;
     heroImage?: ImageMetadata;
+    /**
+     * `view-transition-name` for the hero image. Pages whose hero is their own subject
+     * override it so the image morphs out of the thumbnail that linked here — see
+     * talks/[slug].astro. Everything else keeps the shared default, which makes the
+     * identical pegelbar backdrop hold still instead of crossfading with itself.
+     */
+    heroName?: string;
 }
 
-const { heroTitle, heroSubtitle, heroImage, ...seo } = Astro.props;
+const { heroTitle, heroSubtitle, heroImage, heroName = 'hero-image', ...seo } = Astro.props;
 ---
 
 <!doctype html>
@@ -53,7 +60,7 @@ const { heroTitle, heroSubtitle, heroImage, ...seo } = Astro.props;
     </head>
 
     <body>
-        <Header title={heroTitle ?? seo.title} subtitle={heroSubtitle} heroImage={heroImage} />
+        <Header title={heroTitle ?? seo.title} subtitle={heroSubtitle} heroImage={heroImage} heroName={heroName} />
         <slot />
         <Footer />
         <script>

--- a/src/pages/talks/[slug].astro
+++ b/src/pages/talks/[slug].astro
@@ -125,6 +125,7 @@ const jsonLd = eventSchema({
     description={description}
     mainImage={talk.data.mainImage}
     heroImage={talk.data.mainImage}
+    heroName={`talk-${talk.id}`}
     heroSubtitle={talk.data.textline}
     jsonLd={jsonLd}
 >

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -56,13 +56,13 @@ const description = 'Alle Ausgaben der Talk-Reihe Talk am Pegel in Neuss.';
                             <div
                                 class:list={[odd ? 'timeline-end' : 'timeline-start', 'ms-4 mb-8']}
                             >
-                                <div
-                                    class="card aos aos-fade-up"
-                                    x-data="{ visible: false }"
-                                    x-intersect.once="visible = true"
-                                    :class="visible && 'visible'"
-                                >
-                                    <figure>
+                                {/* The reveal sits on the body, not the whole card, so the
+                                    thumbnail is painted immediately. A view transition
+                                    snapshots the incoming document before IntersectionObserver
+                                    has fired, so an .aos ancestor would hand the morph a fully
+                                    transparent target on the way back from a talk page. */}
+                                <div class="card">
+                                    <figure transition:name={`talk-${talk.id}`}>
                                         <Thumbnail
                                             image={talk.data.mainImage}
                                             preset="wide"
@@ -70,7 +70,12 @@ const description = 'Alle Ausgaben der Talk-Reihe Talk am Pegel in Neuss.';
                                             alt=""
                                         />
                                     </figure>
-                                    <div class="card-body gap-4">
+                                    <div
+                                        class="card-body gap-4 aos aos-fade-up"
+                                        x-data="{ visible: false }"
+                                        x-intersect.once="visible = true"
+                                        :class="visible && 'visible'"
+                                    >
                                         <h2 class="card-title text-lg">
                                             <div class="text-base-content/50 text-sm">
                                                 {talk.data.textline}

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -86,3 +86,23 @@
     display: none !important;
   }
 }
+
+/* Native cross-document view transitions. No JavaScript and no <ClientRouter />: the
+   browser animates between two normally-loaded documents, so Alpine, FlyOnUI and
+   BigPicture keep booting once per page exactly as before. Browsers without support
+   (Firefox, today) simply navigate the way they always did.
+   The paired elements are named with Astro's `transition:name` directive, which emits
+   nothing but a `view-transition-name` rule — see Header/Person/LatestEvent and the
+   talks templates. */
+@view-transition {
+  navigation: auto;
+}
+
+/* Unlike Astro's <ClientRouter />, the native at-rule has no built-in reduced-motion
+   opt-out, so switch navigation off explicitly. Same intent as the `motion-safe:`
+   variant carrying the .aos reveals in aos.css. */
+@media (prefers-reduced-motion: reduce) {
+  @view-transition {
+    navigation: none;
+  }
+}


### PR DESCRIPTION
## Why

Every navigation currently throws away the visual continuity the site already has — the same photograph appears as a card thumbnail on `/talks` and then as the hero on `/talks/<slug>`, and as a round avatar on a talk page and then on `/persons/<slug>`. This animates that link instead of flashing white between them.

## Approach

**Native cross-document view transitions — no `<ClientRouter />`, no added JavaScript.** `@view-transition { navigation: auto }` in `site.css`, plus Astro's `transition:name` directive, which compiles to nothing but a `view-transition-name` rule.

That matters here: `src/scripts/site.ts` starts Alpine, FlyOnUI and BigPicture once at module scope with a one-shot `.image-gallery a` loop, and the ticket CTA compares `Date.now()` against a build-time epoch. A client-side router would mean re-initialising all of it on `astro:page-load` and re-validating the past-event logic. The native route touches none of it, and browsers without support behave exactly as they do today.

## Naming scheme

A `view-transition-name` must be unique **within a document**, which dictates the scheme:

| Name | Element | Pages |
|---|---|---|
| `site-logo` | hero logo SVG | every page |
| `hero-image` | hero background | every page **except** talk detail |
| `talk-<slug>` | `/talks` card figure, home teaser, talk detail hero | one per page |
| `person-<slug>` | `Person.astro` avatar | talk detail, `/persons/<slug>`, `/kontakt` |

`PersonAvatarGroup` is deliberately **not** named — the same person recurs across several cards on `/talks`, and duplicate names abort the entire transition.

## The one behavioural change

A view transition snapshots the incoming document *before* `IntersectionObserver` fires, so anything inside an `.aos` wrapper is captured at `opacity: 0` and the morph lands on something invisible. Measured: the `/talks` card figure at **0.000** effective opacity, and the home teaser image at `display: none`, box `0x0`.

So the card reveal moved from `.card` to `.card-body` (thumbnail paints immediately, text still fades up), and `LatestEvent`'s image lost its redundant `x-cloak` — which also stops the home page `display:none`-ing its own LCP image until Alpine boots.

## Verification

Driven in real Chrome against `dist/` served with production-equivalent headers:

| Path | Transition |
|---|---|
| `/talks` → talk detail | ✅ |
| back → `/talks` | ✅ |
| home → talk detail | ✅ |
| person → talk, back → person | ✅ |
| `/kontakt` → `/impressum` | ✅ |
| reduced motion | ✅ suppressed |

`pnpm verify` 38/38, `astro check` 0 errors, Prettier clean.

## Two things worth knowing

1. **View transitions never appear under `pnpm preview`.** `astro preview` sends `Cache-Control: no-cache`, and Chrome silently refuses a cross-document transition on such a response — `pageswap` fires with a transition, `pagereveal` gets `null`. Isolated by replaying header variants: adding `no-cache` to a working server breaks it, `Vary: Origin` does not. Production sends `public, max-age=0, must-revalidate`, which works. Serve `dist/` with a plain static server to check locally. Noted in CLAUDE.md.

2. **The `person-<slug>` morph is currently reachable only by back-navigation.** `Person.astro` links to external social profiles; nothing links from a talk page to `/persons/<slug>`. It costs nothing and works on `/persons/p` → talk → back, but making the avatar a link would put it on the forward path too. Happy to do that here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
