### PR TITLE
🚀 Stop lazy-loading the hero image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ guidance.
 ```bash
 pnpm dev         # Astro dev server, http://localhost:4321
 pnpm build       # -> dist/
-pnpm verify      # assert dist/ is intact (37 assertions) — also a deploy gate
+pnpm verify      # assert dist/ is intact (41 assertions) — also a deploy gate
 pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (20 checks)
 pnpm check       # astro check
 pnpm preview     # serve dist/

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -16,7 +16,7 @@
  *      still advertises tickets
  *   5. canonical/og:url are extensionless and absolute
  *   6. German date formatting is present where expected
- *   7. Images: every <img> has alt and intrinsic dimensions
+ *   7. Images: every <img> has alt and intrinsic dimensions, and the hero is not lazy
  */
 
 import fs from 'node:fs';
@@ -275,6 +275,29 @@ console.log('\n7. Images');
     }
     noAlt === 0 ? pass(`all ${total} <img> have an alt attribute`) : fail(`${noAlt}/${total} <img> without alt`);
     noDims === 0 ? pass('all <img> declare width and height') : fail(`${noDims}/${total} <img> without intrinsic dimensions`);
+
+    // The hero backdrop is the LCP element on every page, and Thumbnail defaults to
+    // lazy — so a page that loses its `lazy={false}` would silently defer its own
+    // largest paint. Target the first <picture> rather than the first <img>: the
+    // sticky logo bar's plain <img> comes earlier in the markup.
+    let lazyHero = 0;
+    let noPriority = 0;
+    let missing = 0;
+    for (const f of pages) {
+        const hero = read(f).match(/<picture[\s\S]*?<\/picture>/)?.[0];
+        if (!hero) {
+            missing++;
+            continue;
+        }
+        const img = hero.match(/<img\s[^>]*>/)?.[0] ?? '';
+        if (/loading="lazy"/.test(img)) lazyHero++;
+        if (!/fetchpriority="high"/.test(img)) noPriority++;
+    }
+    missing === 0 ? pass(`all ${pages.length} pages render a hero <picture>`) : fail(`${missing} page(s) without a hero <picture>`);
+    lazyHero === 0 ? pass('no page lazy-loads its hero (LCP) image') : fail(`${lazyHero} page(s) lazy-load the LCP image`);
+    noPriority === 0
+        ? pass('every hero image is fetchpriority="high"')
+        : fail(`${noPriority} page(s) hero image without fetchpriority="high"`);
 }
 
 console.log(`\n${failures === 0 ? 'PASS' : 'FAIL'} — ${checks} checks passed, ${failures} failure(s)\n`);

--- a/src/components/Thumbnail.astro
+++ b/src/components/Thumbnail.astro
@@ -52,6 +52,13 @@ interface Props {
     alt?: string;
     sizes?: string;
     lazy?: boolean;
+    /**
+     * Only for the LCP element. `lazy={false}` alone just removes the brake; this
+     * asks for the fetch to jump the queue ahead of the stylesheet and the rest of
+     * the images. Passing it on a below-the-fold image is actively harmful — it
+     * competes with the one image that decides LCP.
+     */
+    fetchpriority?: 'high' | 'low' | 'auto';
     class?: string;
 }
 
@@ -61,6 +68,7 @@ const {
     alt = '',
     sizes = '(min-width: 600px) 50vw, 100vw',
     lazy = true,
+    fetchpriority,
     class: className,
     ...rest
 } = Astro.props;
@@ -101,6 +109,7 @@ const height = aspect ? Math.round(width / aspect) : Math.round((width * image.h
     height={height}
     quality={85}
     loading={lazy ? 'lazy' : 'eager'}
+    fetchpriority={fetchpriority}
     class={className}
     {...rest}
 />

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -54,10 +54,23 @@ const { title, subtitle, heroImage = pegelbar, heroName = 'hero-image' } = Astro
         Thumbnail's rest spread and <Picture>'s own attribute forwarding to land on the
         img. Geometry is unchanged — the img still fills an inset-0 box. */}
     <div class="absolute inset-0 opacity-20" transition:name={heroName}>
+        {/* This full-viewport backdrop is the LCP element on every page of the site, which
+            is why it is eager and high-priority. Thumbnail defaults to lazy — correct for
+            the card and gallery images it was written for, wrong here: `loading="lazy"`
+            makes the browser defer the one paint the score is measured on until layout
+            says it is in view. Layout.astro's font-preload comment already names this
+            image as the LCP element; the attributes now agree with it.
+
+            No <link rel="preload"> to go with it: this <img> sits in the first kilobyte
+            of the body where the preload scanner finds it immediately, and a preload
+            whose imagesrcset/imagesizes drift out of step with Thumbnail's width ladder
+            would fetch the image a second time. */}
         <Thumbnail
             image={heroImage}
             sizes="100vw"
             alt=""
+            lazy={false}
+            fetchpriority="high"
             class="w-full h-full object-cover object-center block"
         />
     </div>


### PR DESCRIPTION
Fixes #1482 — the first fix out of the Website Spec audit (#1495).

### The bug

`src/components/layout/Header.astro` rendered the full-viewport hero via `<Thumbnail>` without `lazy={false}`, and `Thumbnail.astro` defaults `lazy = true`. So the LCP element on **all 58 pages** shipped `loading="lazy"`, telling the browser to defer the one paint Core Web Vitals measures until layout says it is in view.

The reasoning was already in the repo and disagreed with the markup — `Layout.astro`'s font-preload comment explains that fonts are *not* preloaded so they don't "compete with the hero image, which is the actual LCP element."

Spec items closed: [`performance/core-web-vitals`](https://specification.website/spec/performance/core-web-vitals/) (required), [`performance/lazy-loading`](https://specification.website/spec/performance/lazy-loading/), and the LCP half of [`performance/image-optimization`](https://specification.website/spec/performance/image-optimization/).

### The change

- `Header.astro` passes `lazy={false}` and `fetchpriority="high"` for the hero
- `Thumbnail.astro` gains a typed `fetchpriority` prop, documented as LCP-only — passing it on a below-the-fold image competes with the element that actually matters
- `verify.mjs` gains three assertions (38 → 41): every page renders a hero `<picture>`, none lazy-loads it, all are `fetchpriority="high"`

The assertions target the first `<picture>`, not the first `<img>` — the audit's shorthand was slightly off, because the sticky logo bar's plain `<img>` comes earlier in the markup.

### Deliberately not done

**No `<link rel="preload">` for the hero**, despite it being on the issue's checklist. The `<img>` sits in the first kilobyte of the body where the preload scanner finds it immediately, so the gain over `eager` + `fetchpriority="high"` is marginal — while a preload whose `imagesrcset`/`imagesizes` drifted out of step with `Thumbnail`'s width ladder would download the image a second time. That trade-off is now a comment in `Header.astro` so the omission reads as a decision rather than an oversight.

`preconnect` to `cdn.usefathom.com` also skipped: the script is deferred, so it isn't on the critical path.

### Verification

```
pnpm check    # 0 errors
pnpm build    # 58 pages
pnpm verify   # PASS — 41 checks, 0 failures
```

Swept all 58 built pages directly: hero `loading` is `eager` on 58/58, `fetchpriority="high"` on 58/58. Field LCP still wants a real measurement once this is live — noted as a follow-up on #1482 rather than a blocker here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)