### PR TITLE
♿ Give every page a main landmark, a skip link and one h1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ guidance.
 ```bash
 pnpm dev         # Astro dev server, http://localhost:4321
 pnpm build       # -> dist/
-pnpm verify      # assert dist/ is intact (41 assertions) — also a deploy gate
+pnpm verify      # assert dist/ is intact (45 assertions) — also a deploy gate
 pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (20 checks)
 pnpm check       # astro check
 pnpm preview     # serve dist/
@@ -123,20 +123,28 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   the Astro compile.
 - **`past()` is a build-time decision** (`isPast` in `src/lib/content.ts`), where Kirby evaluated it
   per request, and **there is no scheduled rebuild** — Cloudflare deploys on push and nothing else.
-  `talks/[slug].astro` therefore ships *both* states and lets Alpine pick, comparing the reader's
+  `talks/[slug].astro` therefore ships _both_ states and lets Alpine pick, comparing the reader's
   clock against an epoch emitted at build time, so the ticket CTA disappears when the event ends
   rather than at the next deploy. The Alpine bindings use `:class` **object** syntax deliberately:
   only that form removes classes that came from the static `class` attribute, which is what lets the
-  server render the build-time state and the client take it back. The Event JSON-LD does *not*
+  server render the build-time state and the client take it back. The Event JSON-LD does _not_
   self-correct — a past talk advertises `SoldOut` as of the next deploy, and `verify.mjs` asserts it.
 - **A view transition snapshots the incoming page before `IntersectionObserver` fires**, so an
   element inside an `.aos` wrapper is captured at `opacity: 0` and a shared-element morph lands on
-  something invisible. Every reveal therefore sits *beside* a named element, never above it: on
+  something invisible. Every reveal therefore sits _beside_ a named element, never above it: on
   `/talks` it is on `.card-body` rather than `.card`, `LatestEvent`'s image has none at all (nor
   `x-cloak` any more), and `Person.astro` reveals the name and socials rather than the whole
   `<article>`, so the avatar stays painted. Keep `transition:name` off anything a reveal can blank
   out — measure it: probe the incoming element's effective opacity at `pagereveal`, not just that
   the transition fired.
+- **`aria-labelledby` on the repeated "Mehr erfahren" links lists the link's own id first**,
+  then the card heading — `aria-labelledby="talk-x-more talk-x-title"`. The self-reference looks
+  redundant and is not: naming the heading alone would drop the visible words "Mehr erfahren" out
+  of the accessible name, which is what WCAG 2.5.3 (Label in Name) is about. `verify.mjs` asserts
+  every link has _a_ name, so deleting the self-id would still pass — the check cannot see this.
+- **`#content` lives on `<main>`**, which `Layout.astro` wraps around `<slot />`. It is the target
+  of both the skip link and the hero's scroll-down arrow, and it replaced an empty
+  `<span id="content">` that used to sit after the header purely as an anchor.
 - **Do not set HSTS in `public/_headers`.** The Cloudflare zone owns it and overrides anything set
   there — setting a header in both places joins the values with a comma. `nosniff` is different:
   it survives on a `workers.dev` preview, which is outside the zone, so `public/_headers` is
@@ -146,18 +154,18 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   `@source "../**/*.{astro,ts,js,mdx,md}"` as the only supplier of class candidates. So the CSS is
   a function of the markup and nothing else — **a class written outside `src/` is not generated**.
 
-  Detection used to scan the whole repo (minus `.gitignore` and `node_modules`), which swept up
-  prose: any English word matching a FlyOnUI component name generated that component's entire CSS.
-  A code comment cost 4 kB for a component no element here has ever used; the CLAUDE.md paragraph
-  documenting that trap then re-added the same 4 kB by naming it; and deleting the Blade templates
-  had earlier dropped 57 kB the same way. Scoping it removed a further 12.5 kB (96.5 kB → 84 kB) of
-  unused FlyOnUI components — `.input`, `.select`, `.table`, `.filter`, `.validate` and friends.
+    Detection used to scan the whole repo (minus `.gitignore` and `node_modules`), which swept up
+    prose: any English word matching a FlyOnUI component name generated that component's entire CSS.
+    A code comment cost 4 kB for a component no element here has ever used; the CLAUDE.md paragraph
+    documenting that trap then re-added the same 4 kB by naming it; and deleting the Blade templates
+    had earlier dropped 57 kB the same way. Scoping it removed a further 12.5 kB (96.5 kB → 84 kB) of
+    unused FlyOnUI components — `.input`, `.select`, `.table`, `.filter`, `.validate` and friends.
 
-  If you change the scanning again, the check that actually proves it safe is: for every class used
-  in `dist/**/*.html`, assert the emitted CSS carries a rule for it, and diff `getComputedStyle`
-  across the pages before and after. Size alone tells you nothing — a drop is usually dead weight,
-  not a regression. (Note `@apply` resolves from the theme and is unaffected by detection, so
-  `@utility blocks`' `italic` survives even though the standalone `.italic` utility is gone.)
+    If you change the scanning again, the check that actually proves it safe is: for every class used
+    in `dist/**/*.html`, assert the emitted CSS carries a rule for it, and diff `getComputedStyle`
+    across the pages before and after. Size alone tells you nothing — a drop is usually dead weight,
+    not a regression. (Note `@apply` resolves from the theme and is unaffected by detection, so
+    `@utility blocks`' `italic` survives even though the standalone `.italic` utility is gone.)
 
 ## Content
 
@@ -203,7 +211,7 @@ was 2026-09-04, tracked in issue #1495.
   touched. Adding a line is routine; removing one de-indexes a live page and nothing
   downstream can detect it.
 - `Stop` → `pnpm build && pnpm verify`, but only when the turn changed something that
-  reaches `dist/` (fingerprinted over `HEAD` *and* the working tree, so a turn that ends in
+  reaches `dist/` (fingerprinted over `HEAD` _and_ the working tree, so a turn that ends in
   a commit still counts). It runs with `asyncRewake`, so it costs the turn nothing and only
   interrupts on failure. ~14s warm, ~45s when `dist/` is absent.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ guidance.
 ```bash
 pnpm dev         # Astro dev server, http://localhost:4321
 pnpm build       # -> dist/
-pnpm verify      # assert dist/ is intact (45 assertions) — also a deploy gate
+pnpm verify      # assert dist/ is intact (46 assertions) — also a deploy gate
 pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (20 checks)
 pnpm check       # astro check
 pnpm preview     # serve dist/

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -17,8 +17,9 @@
  *   5. canonical/og:url are extensionless and absolute
  *   6. German date formatting is present where expected
  *   7. Images: every <img> has alt and intrinsic dimensions, and the hero is not lazy
- *   8. Document structure: one <main>, one <h1>, no skipped heading level,
- *      and no link without an accessible name
+ *   8. Document structure: one <main>, one <h1>, no skipped heading level, every
+ *      link resolving to a non-empty accessible name, and no dangling
+ *      aria-labelledby reference
  */
 
 import fs from 'node:fs';
@@ -62,6 +63,90 @@ const toUrl = (f) =>
 
 const pages = htmlFiles();
 const read = (f) => fs.readFileSync(f, 'utf8');
+
+const VOID_TAGS = new Set(['img', 'input', 'br', 'hr', 'source', 'meta', 'link', 'area']);
+
+/**
+ * Entities have to be DECODED, not blanked: /kontakt writes its mailto address as
+ * numeric character references to frustrate harvesters, and treating those as
+ * whitespace makes a perfectly well-named link look nameless.
+ */
+const ENTITIES = {
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+    nbsp: ' ',
+    shy: '',
+    copy: '©',
+    ndash: '–',
+    mdash: '—',
+    hellip: '…',
+    laquo: '«',
+    raquo: '»',
+    bdquo: '„',
+    ldquo: '“',
+    rdquo: '”',
+    euro: '€',
+    auml: 'ä',
+    ouml: 'ö',
+    uuml: 'ü',
+    Auml: 'Ä',
+    Ouml: 'Ö',
+    Uuml: 'Ü',
+    szlig: 'ß',
+};
+
+const decodeEntities = (s) =>
+    s
+        .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+        .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
+        // An unknown named entity is still content, so it must not decode to whitespace.
+        .replace(/&([a-zA-Z][a-zA-Z0-9]*);/g, (_, name) => (name in ENTITIES ? ENTITIES[name] : '\uFFFD'));
+
+/** Visible text of an element, tags stripped and entities decoded. */
+const textOf = (html) =>
+    decodeEntities(html.replace(/<[^>]*>/g, ' '))
+        .replace(/\s+/g, ' ')
+        .trim();
+
+/**
+ * Text content of the element carrying `id`, or null when no such id exists on the page.
+ * Walks forward counting same-name tags rather than regex-matching to the first close tag,
+ * so a heading containing a nested <span> resolves to the whole heading.
+ *
+ * Needed because an aria-labelledby pointing at an id that is not on the page yields an
+ * EMPTY accessible name while looking perfectly correct in the markup — the failure mode
+ * a presence-only check cannot see.
+ */
+function textById(html, id) {
+    const at = html.search(new RegExp(`\\sid="${id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`));
+    if (at === -1) return null;
+    const open = html.lastIndexOf('<', at);
+    const tag = html
+        .slice(open + 1)
+        .match(/^[a-zA-Z][\w-]*/)?.[0]
+        ?.toLowerCase();
+    if (!tag) return null;
+    const openEnd = html.indexOf('>', at);
+    if (openEnd === -1) return null;
+    if (VOID_TAGS.has(tag)) {
+        // A void element's name comes from its own attributes, not children.
+        const alt = html.slice(open, openEnd + 1).match(/\salt="([^"]*)"/)?.[1];
+        return alt === undefined ? '' : decodeEntities(alt).trim();
+    }
+    let depth = 1;
+    let i = openEnd + 1;
+    const scan = new RegExp(`<(/?)${tag}[\\s>/]`, 'g');
+    scan.lastIndex = i;
+    let m;
+    while ((m = scan.exec(html))) {
+        depth += m[1] ? -1 : 1;
+        if (depth === 0) return textOf(html.slice(openEnd + 1, m.index));
+    }
+    return textOf(html.slice(openEnd + 1));
+}
 
 // ---------------------------------------------------------------- 1. inventory
 console.log('\n1. URL inventory');
@@ -311,6 +396,8 @@ console.log('\n8. Document structure');
     let skipped = 0;
     let nameless = 0;
     let anchors = 0;
+    let references = 0;
+    let dangling = 0;
 
     for (const f of pages) {
         const html = read(f);
@@ -332,24 +419,33 @@ console.log('\n8. Document structure');
             prev = level;
         }
 
-        // An <a> whose name is empty is unusable in a screen reader's link list. A name
-        // can come from text content, an aria-label/aria-labelledby/title on the anchor,
-        // or a named <img>/<svg> inside it — icon-only links have none of those unless
-        // they say so explicitly.
+        // An <a> whose name is empty is unusable in a screen reader's link list. Resolve
+        // the name the way the accessibility tree does, in precedence order — the mere
+        // PRESENCE of aria-labelledby or aria-label is not a name: the referenced ids can
+        // be absent from the page, and the attribute value can be empty.
         for (const m of html.matchAll(/<a\s[^>]*>([\s\S]*?)<\/a>/g)) {
             anchors++;
             const tag = m[0].slice(0, m[0].indexOf('>') + 1);
             const inner = m[1];
-            if (/\saria-label(ledby)?=|\stitle=/.test(tag)) continue;
-            if (
-                inner
-                    .replace(/<[^>]*>/g, ' ')
-                    .replace(/&[a-z]+;/g, ' ')
-                    .trim()
-            )
-                continue;
-            if (/<img[^>]*\salt="[^"]+"/.test(inner) || /aria-label=/.test(inner)) continue;
-            nameless++;
+
+            const labelledby = tag.match(/\saria-labelledby="([^"]*)"/)?.[1];
+            let name = '';
+
+            if (labelledby !== undefined) {
+                for (const id of labelledby.split(/\s+/).filter(Boolean)) {
+                    const text = textById(html, id);
+                    if (text === null) dangling++;
+                    else name += ` ${text}`;
+                }
+                references += labelledby.split(/\s+/).filter(Boolean).length;
+            }
+            if (!name.trim()) name = tag.match(/\saria-label="([^"]*)"/)?.[1] ?? '';
+            if (!name.trim()) name = textOf(inner);
+            if (!name.trim()) name = inner.match(/\salt="([^"]*)"/)?.[1] ?? '';
+            if (!name.trim()) name = inner.match(/\saria-label="([^"]*)"/)?.[1] ?? '';
+            if (!name.trim()) name = tag.match(/\stitle="([^"]*)"/)?.[1] ?? '';
+
+            if (!name.trim()) nameless++;
         }
     }
 
@@ -359,8 +455,11 @@ console.log('\n8. Document structure');
     wrongH1 === 0 ? pass('every page has exactly one <h1>') : fail(`${wrongH1} page(s) without exactly one <h1>`);
     skipped === 0 ? pass('no page skips a heading level') : fail(`${skipped} skipped heading level(s)`);
     nameless === 0
-        ? pass(`all ${anchors} <a> elements have an accessible name`)
+        ? pass(`all ${anchors} <a> elements resolve to a non-empty accessible name`)
         : fail(`${nameless}/${anchors} <a> without an accessible name`);
+    dangling === 0
+        ? pass(`all ${references} aria-labelledby references resolve to an element on the page`)
+        : fail(`${dangling}/${references} aria-labelledby references point at a missing id`);
 }
 
 console.log(`\n${failures === 0 ? 'PASS' : 'FAIL'} — ${checks} checks passed, ${failures} failure(s)\n`);

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -17,6 +17,8 @@
  *   5. canonical/og:url are extensionless and absolute
  *   6. German date formatting is present where expected
  *   7. Images: every <img> has alt and intrinsic dimensions, and the hero is not lazy
+ *   8. Document structure: one <main>, one <h1>, no skipped heading level,
+ *      and no link without an accessible name
  */
 
 import fs from 'node:fs';
@@ -298,6 +300,67 @@ console.log('\n7. Images');
     noPriority === 0
         ? pass('every hero image is fetchpriority="high"')
         : fail(`${noPriority} page(s) hero image without fetchpriority="high"`);
+}
+
+// ------------------------------------------------------- 8. document structure
+console.log('\n8. Document structure');
+{
+    let noMain = 0;
+    let manyMain = 0;
+    let wrongH1 = 0;
+    let skipped = 0;
+    let nameless = 0;
+    let anchors = 0;
+
+    for (const f of pages) {
+        const html = read(f);
+
+        const mains = (html.match(/<main[\s>]/g) ?? []).length;
+        if (mains === 0) noMain++;
+        else if (mains > 1) manyMain++;
+
+        // Exactly one — zero leaves the page without a top-level heading, more than one
+        // flattens the outline. The home page shipped two for the whole of the migration.
+        if ((html.match(/<h1[\s>]/g) ?? []).length !== 1) wrongH1++;
+
+        // Headings must nest, not jump: h2 -> h4 leaves a hole in the outline that a
+        // screen-reader user navigating by heading level cannot see past.
+        let prev = 0;
+        for (const m of html.matchAll(/<h([1-6])[\s>]/g)) {
+            const level = Number(m[1]);
+            if (prev && level > prev + 1) skipped++;
+            prev = level;
+        }
+
+        // An <a> whose name is empty is unusable in a screen reader's link list. A name
+        // can come from text content, an aria-label/aria-labelledby/title on the anchor,
+        // or a named <img>/<svg> inside it — icon-only links have none of those unless
+        // they say so explicitly.
+        for (const m of html.matchAll(/<a\s[^>]*>([\s\S]*?)<\/a>/g)) {
+            anchors++;
+            const tag = m[0].slice(0, m[0].indexOf('>') + 1);
+            const inner = m[1];
+            if (/\saria-label(ledby)?=|\stitle=/.test(tag)) continue;
+            if (
+                inner
+                    .replace(/<[^>]*>/g, ' ')
+                    .replace(/&[a-z]+;/g, ' ')
+                    .trim()
+            )
+                continue;
+            if (/<img[^>]*\salt="[^"]+"/.test(inner) || /aria-label=/.test(inner)) continue;
+            nameless++;
+        }
+    }
+
+    noMain === 0 && manyMain === 0
+        ? pass(`all ${pages.length} pages have exactly one <main>`)
+        : fail(`${noMain} page(s) without <main>, ${manyMain} with more than one`);
+    wrongH1 === 0 ? pass('every page has exactly one <h1>') : fail(`${wrongH1} page(s) without exactly one <h1>`);
+    skipped === 0 ? pass('no page skips a heading level') : fail(`${skipped} skipped heading level(s)`);
+    nameless === 0
+        ? pass(`all ${anchors} <a> elements have an accessible name`)
+        : fail(`${nameless}/${anchors} <a> without an accessible name`);
 }
 
 console.log(`\n${failures === 0 ? 'PASS' : 'FAIL'} — ${checks} checks passed, ${failures} failure(s)\n`);

--- a/src/components/LatestEvent.astro
+++ b/src/components/LatestEvent.astro
@@ -38,14 +38,25 @@ const href = `/talks/${talk.id}`;
             x-intersect="setTimeout(function() { visible = true }, 200)"
             :class="visible && 'visible'"
         >
-            <h1 class="text-base-content text-3xl font-semibold sm:text-4xl">
-                <a href={href} class="link link-hover decoration-accent" set:html={widont(talk.data.title)} />
-            </h1>
+            {
+                /* <h2>, not <h1>: the hero already carries the page's only <h1>, and two
+                of them flattened the home page's outline. */
+            }
+            <h2 class="text-base-content text-3xl font-semibold sm:text-4xl">
+                <a id="latest-talk-title" href={href} class="link link-hover decoration-accent" set:html={widont(talk.data.title)} />
+            </h2>
             <p class="text-base-content/60 text-sm">
                 {talk.data.textline} am {formatDate(talk.data.date)}
             </p>
             <p class="text-base-content max-w-xl leading-relaxed">{description}</p>
-            <a href={href} class="btn btn-accent">Mehr erfahren</a>
+            {
+                /* aria-labelledby lists this link first, then the heading, so the name reads
+                "Mehr erfahren <talk title>" — keeping the visible label inside the
+                accessible name (WCAG 2.5.3) while still disambiguating the target. */
+            }
+            <a id="latest-talk-more" href={href} class="btn btn-accent" aria-labelledby="latest-talk-more latest-talk-title">
+                Mehr erfahren
+            </a>
         </div>
     </article>
 

--- a/src/components/blocks/Gallery.astro
+++ b/src/components/blocks/Gallery.astro
@@ -45,7 +45,7 @@ const lightboxes = await Promise.all(
     <div class:list={['grid', cols, 'gap-2', 'image-gallery', 'not-prose']}>
         {
             images.map((image, i) => (
-                <a href={lightboxes[i].src} class="aspect-3/2">
+                <a href={lightboxes[i].src} class="aspect-3/2" aria-label={`Bild ${i + 1} von ${count} vergrößern`}>
                     <Thumbnail
                         image={image}
                         preset="landscape"

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -13,7 +13,7 @@ const year = new Date().getFullYear();
 ---
 
 <footer class="footer footer-center bg-base-300/60 mt-12 p-12">
-    <nav class="text-base-content grid grid-flow-col gap-4">
+    <nav class="text-base-content grid grid-flow-col gap-4" aria-label="Rechtliches und Kontakt">
         {
             footerNavigation.map((item) => (
                 <a href={item.href} class="link link-hover">
@@ -22,7 +22,7 @@ const year = new Date().getFullYear();
             ))
         }
     </nav>
-    <nav>
+    <nav aria-label="Soziale Netzwerke">
         <div class="flex gap-4">
             <a
                 href={`https://facebook.com/${site.facebook}`}

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -43,8 +43,12 @@ const { title, subtitle, heroImage = pegelbar, heroName = 'hero-image' } = Astro
     >
         <a href="/" class="flex justify-center">
             {/* Intrinsic size from the SVG's own viewBox; h-8 scales it. Kirby set
-                neither, leaving the img without an aspect ratio. */}
-            <img src="/img/logo.svg" class="h-8" alt="" width="212" height="40" />
+                neither, leaving the img without an aspect ratio.
+
+                The alt text is load-bearing rather than decorative: this img is the
+                only content of the link, so alt="" left the link with no accessible
+                name at all — on all 58 pages. */}
+            <img src="/img/logo.svg" class="h-8" alt="Talk am Pegel" width="212" height="40" />
         </a>
     </div>
 
@@ -110,11 +114,11 @@ const { title, subtitle, heroImage = pegelbar, heroName = 'hero-image' } = Astro
             }
         </div>
         <div class="z-10 text-center w-full md:hidden py-6">
-            <a href="#content" class="btn btn-accent btn-circle btn-lg">
+            {/* Icon-only link: the arrow glyph is decorative, so the name has to come
+                from aria-label. */}
+            <a href="#content" class="btn btn-accent btn-circle btn-lg" aria-label="Zum Inhalt scrollen">
                 <Icon name="ri:arrow-down-line" class="size-6 shrink-0" />
             </a>
         </div>
     </div>
 </header>
-
-<span id="content"></span>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -60,8 +60,31 @@ const { heroTitle, heroSubtitle, heroImage, heroName = 'hero-image', ...seo } = 
     </head>
 
     <body>
+        {
+            /*
+          Skip link, first focusable thing on the page: every page opens with a
+          full-viewport hero and a logo bar, so without it a keyboard user traverses
+          the whole header before reaching content. Hidden until focused.
+        */
+        }
+        <a
+            href="#content"
+            class="focus:bg-primary focus:text-primary-content sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[60] focus:rounded-sm focus:px-4 focus:py-2 focus:no-underline focus:outline-2 focus:outline-offset-2"
+        >
+            Zum Inhalt springen
+        </a>
         <Header title={heroTitle ?? seo.title} subtitle={heroSubtitle} heroImage={heroImage} heroName={heroName} />
-        <slot />
+        {
+            /*
+          The site's only <main>, and the target of both the skip link and the hero's
+          scroll-down arrow — it replaces the empty <span id="content"> that used to sit
+          after the header purely as an anchor. tabindex="-1" so the skip link actually
+          moves focus here rather than only scrolling.
+        */
+        }
+        <main id="content" tabindex="-1">
+            <slot />
+        </main>
         <Footer />
         <script>
             import '../scripts/site.ts';

--- a/src/pages/persons/index.astro
+++ b/src/pages/persons/index.astro
@@ -25,8 +25,17 @@ const description = `Die Gäste der Talk-Reihe ${site.title} in Neuss.`;
                 {
                     all.map((person) => (
                         <li>
-                            <h2 class="mb-2 text-2xl font-medium text-gray-900 dark:text-gray-100">{person.data.title}</h2>
-                            <a href={`/persons/${person.id}`} class="btn btn-sm btn-soft btn-accent">
+                            <h2 id={`person-${person.id}-title`} class="mb-2 text-2xl font-medium text-gray-900 dark:text-gray-100">
+                                {person.data.title}
+                            </h2>
+                            {/* 40 identical "Mehr erfahren" links on one page — each name is
+                                paired with its own heading. */}
+                            <a
+                                id={`person-${person.id}-more`}
+                                href={`/persons/${person.id}`}
+                                class="btn btn-sm btn-soft btn-accent"
+                                aria-labelledby={`person-${person.id}-more person-${person.id}-title`}
+                            >
                                 Mehr erfahren
                                 <Icon name="ri:arrow-right-line" class="size-5 max-sm:hidden" />
                             </a>

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -81,15 +81,21 @@ const description = 'Alle Ausgaben der Talk-Reihe Talk am Pegel in Neuss.';
                                                 {talk.data.textline}
                                                 <span class="sr-only">:</span>
                                             </div>
-                                            {talk.data.title}
+                                            <span id={`talk-${talk.id}-title`}>{talk.data.title}</span>
                                         </h2>
 
                                         <PersonAvatarGroup persons={attendants} />
 
                                         <div class="card-actions">
+                                            {/* "Mehr erfahren" repeats on every card, so the
+                                                accessible name pairs it with that card's
+                                                title. The link is listed first so its own
+                                                visible text stays part of the name. */}
                                             <a
+                                                id={`talk-${talk.id}-more`}
                                                 href={`/talks/${talk.id}`}
                                                 class="btn btn-sm btn-soft btn-accent"
+                                                aria-labelledby={`talk-${talk.id}-more talk-${talk.id}-title`}
                                             >
                                                 Mehr erfahren
                                                 <Icon


### PR DESCRIPTION
Fixes #1480 — second fix out of the audit (#1495), and the last of the three P0s that don't need a design decision.

Four **required** spec items, all symptoms of the same thing: [`accessibility/semantic-html`](https://specification.website/spec/accessibility/semantic-html/), [`accessibility/skip-links`](https://specification.website/spec/accessibility/skip-links/), [`accessibility/link-text`](https://specification.website/spec/accessibility/link-text/), [`seo/heading-hierarchy`](https://specification.website/spec/seo/heading-hierarchy/).

### Landmark and skip link

`Layout.astro` wraps `<slot />` in `<main id="content">` and opens `<body>` with a skip link ("Zum Inhalt springen", hidden until focused). `#content` was previously an empty `<span>` sitting after the header that nothing linked to — it is now the landmark itself, and the target of both the skip link and the hero's scroll-down arrow. `tabindex="-1"` so focus actually moves rather than the page merely scrolling.

Every page opens with a full-viewport hero plus a logo bar, so before this a keyboard user traversed the whole header on every navigation.

### One `<h1>`

`LatestEvent`'s title drops to `<h2>`. The hero already carries the page's only `<h1>`, and the home page has shipped two since the migration.

### Nameless links: 131, not 2

The audit flagged the scroll arrow. Sweeping `dist/` for anchors with no accessible name found three groups:

| group | count | fix |
|---|---|---|
| hero scroll-down arrow (icon-only) | 58 | `aria-label="Zum Inhalt scrollen"` |
| sticky logo bar — `<img alt="">` as the link's only content | 58 | alt text becomes load-bearing: `alt="Talk am Pegel"` |
| gallery lightbox links | 15 | `aria-label="Bild N von M vergrößern"` |

The sticky logo one is the interesting miss: `alt=""` is correct for a decorative image and wrong when that image *is* the link, which left 58 links with no name at all.

The repeated "Mehr erfahren" links on `/talks` and `/persons` now name their own card. `aria-labelledby` lists the link's own id **first**, then the heading — `aria-labelledby="talk-x-more talk-x-title"` — so the name reads "Mehr erfahren <title>" and the visible label stays inside the accessible name ([WCAG 2.5.3](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html)). Naming the heading alone would have dropped the visible words out of the name. CLAUDE.md records why that self-reference isn't redundant, because `verify.mjs` asserts only that *a* name exists and cannot catch its removal.

### Verification

`verify.mjs` gains section 8, 41 → **45 assertions**: exactly one `<main>`, exactly one `<h1>`, no skipped heading level, no `<a>` without an accessible name.

```
pnpm check    # 0 errors
pnpm build    # 58 pages
pnpm verify   # PASS — 45 checks, 0 failures
```

Checked beyond the assertions: all **104** `aria-labelledby` references resolve to ids that exist (a dangling reference yields an empty name and would pass a naive check), zero duplicate ids across all 58 pages, and the skip link is the first element in `<body>`. The heading-skip check passed on its first run — it's there to keep it that way.

Prettier skipped `Header.astro` and `pages/talks/index.astro` as `.prettierignore` intends; `x-intersect.once` is intact in both.

### Not included

Descriptive `alt` text for the ~15 gallery event photos. That is per-image human authoring, not a mechanical fix — the links now have names, and the images stay `alt=""` as decorative. Worth a content pass someday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)