### PR TITLE
🔒 Add the missing security and caching response headers

### DIFF
--- a/.claude/skills/verify-live/SKILL.md
+++ b/.claude/skills/verify-live/SKILL.md
@@ -16,12 +16,17 @@ scripts/verify-live.sh                                   # production
 scripts/verify-live.sh https://<hash>.talk-am-pegel.workers.dev   # a PR preview
 ```
 
-20 checks, read-only, ~30 seconds. Exit 0 on PASS, 1 on FAIL.
+27 checks, read-only, ~30 seconds. Exit 0 on PASS, 1 on FAIL.
 
-Against a `workers.dev` preview it runs 17 and marks 3 as skipped (`-`), because the
+Against a `workers.dev` preview it runs 24 and marks 3 as skipped (`-`), because the
 apex redirect, HSTS and the managed `robots.txt` block are zone behaviours and a preview
 hostname is outside the zone. That is expected, not a regression — the script detects the
 host itself, so a preview run should still say PASS.
+
+A preview run is the _only_ way to test a `public/_headers` change before it reaches
+production: `dist/_headers` is an instruction file for Cloudflare rather than output, so
+`verify.mjs` cannot tell whether the platform accepted it, and a typo in that file fails
+silently. Run this script against the PR's preview URL.
 
 ## When to run it
 
@@ -31,23 +36,24 @@ host itself, so a preview run should still say PASS.
   `not_found_handling` all change edge behaviour invisibly to the build.
 - **After any Cloudflare dashboard change.** This is the main reason the script exists.
   Four things the repo cannot see live in the zone: the apex→www redirect, HSTS, the
-  security-headers transform, and the managed AI-bot block that Cloudflare *prepends* to
+  security-headers transform, and the managed AI-bot block that Cloudflare _prepends_ to
   `robots.txt`. That last one has silently stopped firing once already, and nothing in
   CI would have noticed.
 
 ## Reading a failure
 
-| Failing section | What it usually means |
-| --- | --- |
-| 1, some URLs 404 | The deploy did not include them, or a slug changed. Compare against `scripts/expected-urls.txt`. |
-| 1, a URL **redirects** | The regression this whole repo is built to prevent. Check `trailingSlash`/`build.format` in `astro.config.mjs` and `html_handling` in `wrangler.jsonc`; all three have to agree. |
-| 2, `/talks` or `/persons` 404 | `dist/` holds both `talks.html` and a `talks/` directory. Resolution order puts the file first — no Cloudflare doc covers the collision, so treat a change here as undocumented behaviour that must be re-established empirically. |
-| 3, no 307 | Canonicalisation is off; `.html` and trailing-slash variants would be indexable duplicates. |
-| 4 | The apex DNS record lost its proxied hostname. It must stay a proxied `A` record for the redirect to attach. |
-| 5, bodyless 404 | `not_found_handling` fell back to its `"none"` default. |
-| 6, HTML cached | Static HTML being cached at the edge means content changes stop appearing. |
-| 7 | A zone setting was switched off. **Do not fix this in `public/_headers`** — the zone wins, and setting a header in both places joins the values with a comma. |
-| 8, no `Content-Signal` | Cloudflare has stopped prepending its managed block. Re-enable the toggle in the dashboard; it is not a repo change. |
+| Failing section               | What it usually means                                                                                                                                                                                                                             |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1, some URLs 404              | The deploy did not include them, or a slug changed. Compare against `scripts/expected-urls.txt`.                                                                                                                                                  |
+| 1, a URL **redirects**        | The regression this whole repo is built to prevent. Check `trailingSlash`/`build.format` in `astro.config.mjs` and `html_handling` in `wrangler.jsonc`; all three have to agree.                                                                  |
+| 2, `/talks` or `/persons` 404 | `dist/` holds both `talks.html` and a `talks/` directory. Resolution order puts the file first — no Cloudflare doc covers the collision, so treat a change here as undocumented behaviour that must be re-established empirically.                |
+| 3, no 307                     | Canonicalisation is off; `.html` and trailing-slash variants would be indexable duplicates.                                                                                                                                                       |
+| 4                             | The apex DNS record lost its proxied hostname. It must stay a proxied `A` record for the redirect to attach.                                                                                                                                      |
+| 5, bodyless 404               | `not_found_handling` fell back to its `"none"` default.                                                                                                                                                                                           |
+| 6, HTML cached                | Static HTML being cached at the edge means content changes stop appearing.                                                                                                                                                                        |
+| 7, HSTS                       | A zone setting was switched off. **Do not fix this in `public/_headers`** — the zone wins, and setting a header in both places joins the values with a comma.                                                                                     |
+| 7, anything else              | These come from the `/*` block in `public/_headers`, so the fix _is_ in this repo. A missing one usually means the file was mis-parsed — Cloudflare drops a malformed line and keeps the rest, so the neighbours still passing tells you nothing. |
+| 8, no `Content-Signal`        | Cloudflare has stopped prepending its managed block. Re-enable the toggle in the dashboard; it is not a repo change.                                                                                                                              |
 
 ## What it deliberately does not check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ guidance.
 pnpm dev         # Astro dev server, http://localhost:4321
 pnpm build       # -> dist/
 pnpm verify      # assert dist/ is intact (46 assertions) — also a deploy gate
-pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (20 checks)
+pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (27 checks)
 pnpm check       # astro check
 pnpm preview     # serve dist/
 pnpm deploy:cf   # build + verify + wrangler deploy

--- a/public/_headers
+++ b/public/_headers
@@ -12,12 +12,42 @@
 # still set below because its source is ambiguous — Cloudflare's HSTS panel has an
 # optional No-Sniff toggle, and no duplication is observed either way, so keeping it
 # is the safe side of the trade.
+#
+# Cloudflare applies every matching rule, so the /* block below reaches the hashed
+# assets too; only Cache-Control differs between the two.
 
 # Content-hashed by Astro, so the filename changes whenever the bytes do — safe to
-# cache forever. Everything else keeps the default `max-age=0, must-revalidate`,
-# which is what HTML wants and yields cheap ETag 304s.
+# cache forever. Everything else keeps the default `max-age=0, must-revalidate`, which
+# is what HTML wants.
+#
+# It does NOT yield ETag 304s, which an earlier version of this comment claimed:
+# Workers static assets send a validator for /_astro/* (confirmed 304 on
+# If-None-Match) but none at all for HTML documents, so an HTML revalidation is a
+# full re-fetch. Tracked in issue #1494 with the other platform limits.
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable
 
 /*
   X-Content-Type-Options: nosniff
+  # Nothing here is meant to be framed, and the site has no embed use case. Replace
+  # with CSP frame-ancestors 'none' once a policy exists (issue #1487) — until then
+  # this is the only clickjacking protection the site has.
+  X-Frame-Options: DENY
+  # Send the full URL within the site, only the origin when leaving it. The default
+  # varies by browser, so it is worth stating.
+  Referrer-Policy: strict-origin-when-cross-origin
+  # None of these APIs is used anywhere in src/, so deny them outright: a compromised
+  # or injected script cannot ask for what the policy refuses. browsing-topics opts the
+  # site out of Chrome's Topics API, which is on by default. `interest-cohort` is
+  # deliberately absent — FLoC is dead and the token now only produces console noise.
+  Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), browsing-topics=()
+  # Isolate the browsing context from anything that opens or is opened by it. Safe here
+  # because nothing calls window.open and no flow depends on a popup talking back.
+  Cross-Origin-Opener-Policy: same-origin
+  # Only this site may embed these responses. COEP require-corp is NOT set: it would
+  # need the Fathom script to be crossorigin-clean and belongs with the CSP work.
+  Cross-Origin-Resource-Policy: same-site
+  # Precautionary rather than load-bearing: the site has no query-string routes today,
+  # so nothing varies on these. It matters the moment a campaign link is shared — a
+  # prefetch of /talks?utm_source=x can then satisfy a visit to /talks.
+  No-Vary-Search: params=("utm_source" "utm_medium" "utm_campaign" "utm_content" "utm_term" "gclid" "fbclid" "msclkid" "ref"), key-order

--- a/scripts/verify-live.sh
+++ b/scripts/verify-live.sh
@@ -157,6 +157,46 @@ fi
 xcto=$(hdr x-content-type-options "$h")
 [ "$xcto" = "nosniff" ] && ok "X-Content-Type-Options: nosniff" || no "X-Content-Type-Options is '$xcto', expected nosniff"
 
+# The rest of the /* block in public/_headers. All of it is invisible to verify.mjs —
+# dist/_headers is a Cloudflare instruction file, not output, so only a live response
+# proves the platform parsed and applied it. A typo in that file fails silently.
+xfo=$(hdr x-frame-options "$h")
+[ "$xfo" = "DENY" ] && ok "X-Frame-Options: DENY" || no "X-Frame-Options is '$xfo', expected DENY"
+
+ref=$(hdr referrer-policy "$h")
+[ "$ref" = "strict-origin-when-cross-origin" ] && ok "Referrer-Policy: $ref" || no "Referrer-Policy is '$ref', expected strict-origin-when-cross-origin"
+
+pp=$(hdr permissions-policy "$h")
+case "$pp" in
+    *camera=\(\)*microphone=\(\)*) ok "Permissions-Policy denies the unused device APIs" ;;
+    "") no "no Permissions-Policy" ;;
+    *) no "Permissions-Policy present but does not deny camera/microphone: $pp" ;;
+esac
+
+coop=$(hdr cross-origin-opener-policy "$h")
+[ "$coop" = "same-origin" ] && ok "Cross-Origin-Opener-Policy: $coop" || no "Cross-Origin-Opener-Policy is '$coop', expected same-origin"
+
+corp=$(hdr cross-origin-resource-policy "$h")
+[ "$corp" = "same-site" ] && ok "Cross-Origin-Resource-Policy: $corp" || no "Cross-Origin-Resource-Policy is '$corp', expected same-site"
+
+nvs=$(hdr no-vary-search "$h")
+case "$nvs" in
+    *utm_source*) ok "No-Vary-Search ignores the campaign params" ;;
+    "") no "no No-Vary-Search" ;;
+    *) no "No-Vary-Search present but without utm_source: $nvs" ;;
+esac
+
+# The /* block must reach the hashed assets too, or the security headers cover only
+# HTML. Cloudflare applies every matching rule, so this is a check on that behaviour
+# continuing to hold, not on our own file.
+# $asset is the path picked up in section 6, and may be empty if the parse failed.
+if [ -n "$asset" ]; then
+    a=$(headers "$BASE$asset")
+    [ "$(hdr x-frame-options "$a")" = "DENY" ] && ok "the /* headers reach /_astro/* as well" || no "/_astro/* did not inherit the /* security headers"
+else
+    skip "asset header inheritance not checked (no /_astro asset found on the home page)"
+fi
+
 # ---------------------------------------------------------------------------
 echo
 echo "8. robots.txt and sitemap.xml"


### PR DESCRIPTION
Fixes #1484 — the first P1 out of the audit (#1495). One `/*` block in `public/_headers` closes six spec items.

Before this the site sent nothing but `nosniff`: no clickjacking protection at all, no referrer policy, and no statement about which browser APIs it wants.

| header | why | spec item |
|---|---|---|
| `X-Frame-Options: DENY` | nothing here is meant to be framed; this is the **required** item, and the only clickjacking protection until CSP lands | [`frame-ancestors`](https://specification.website/spec/security/frame-ancestors/) |
| `Referrer-Policy: strict-origin-when-cross-origin` | the browser default varies, so it is worth stating | [`referrer-policy`](https://specification.website/spec/security/referrer-policy/) |
| `Permissions-Policy: …` | denies the device APIs nothing in `src/` uses, so an injected script cannot ask for them; also opts out of Chrome's Topics API, which is **on by default** | [`permissions-policy`](https://specification.website/spec/security/permissions-policy/) |
| `Cross-Origin-Opener-Policy: same-origin` | safe — nothing calls `window.open`, no flow needs a popup talking back | [`cross-origin-isolation`](https://specification.website/spec/security/cross-origin-isolation/) |
| `Cross-Origin-Resource-Policy: same-site` | only this site may embed these responses | ↑ |
| `No-Vary-Search: params=("utm_source" …), key-order` | precautionary: no query-string routes exist today, so it only starts mattering once a campaign link is shared and a prefetch can satisfy the visit | [`no-vary-search`](https://specification.website/spec/performance/no-vary-search/) |

`interest-cohort` is deliberately absent from the Permissions-Policy — FLoC is dead and the token now only produces console noise.

### Deliberately excluded

- **HSTS** — the zone owns it (`max-age=15552000; includeSubDomains` live). Setting it here too comma-joins the value, per CLAUDE.md.
- **COEP `require-corp`** — needs the Fathom script to be crossorigin-clean, so it belongs with the CSP work in #1487, where it can be tested rather than hoped for.

### A false comment corrected

That file claimed the HTML cache regime "yields cheap ETag 304s". It does not: Workers static assets send a validator for `/_astro/*` (confirmed 304 on `If-None-Match`) but **none at all** for HTML documents, so an HTML revalidation is a full re-fetch. That's the first checkbox of #1494 — the comment is now accurate and points at the issue.

### Verification — the part that matters here

`verify.mjs` **cannot** check any of this. `dist/_headers` is an instruction file for Cloudflare, not output; the platform silently drops a malformed line and keeps the rest, so neighbouring headers passing tells you nothing. Only a live response proves it parsed.

So `verify-live.sh` gains seven checks (20 → **27**), including one asserting the `/*` block reaches `/_astro/*` as well — that depends on Cloudflare applying every matching rule, which is platform behaviour worth pinning.

I ran the new checks against **current production before this deploy** and confirmed all seven **fail** there:

```
✓ HSTS: max-age=15552000; includeSubDomains
✓ X-Content-Type-Options: nosniff
✗ X-Frame-Options is '', expected DENY
✗ Referrer-Policy is '', expected strict-origin-when-cross-origin
✗ no Permissions-Policy
✗ Cross-Origin-Opener-Policy is '', expected same-origin
✗ Cross-Origin-Resource-Policy is '', expected same-site
✗ no No-Vary-Search
✗ /_astro/* did not inherit the /* security headers
```

A check that passes before the fix is worthless, so that inversion is the evidence. **I'll run `scripts/verify-live.sh <preview-url>` against this PR's preview deployment and post the result here before this is merged** — a `workers.dev` host is off-zone, so it skips the 3 zone checks but exercises every `_headers`-sourced one.

`pnpm verify` unchanged at 46 checks, PASS. The verify-live skill now documents that a preview run is the only pre-production test for a `_headers` change, and its failure table distinguishes the zone-owned HSTS row from the repo-owned rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)