### PR TITLE
🧱 Make the reveals survive their JavaScript, and fix the hero fade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ guidance.
 ```bash
 pnpm dev         # Astro dev server, http://localhost:4321
 pnpm build       # -> dist/
-pnpm verify      # assert dist/ is intact (46 assertions) — also a deploy gate
+pnpm verify      # assert dist/ is intact (49 assertions) — also a deploy gate
 pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (27 checks)
 pnpm check       # astro check
 pnpm preview     # serve dist/
@@ -137,6 +137,27 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   `<article>`, so the avatar stays painted. Keep `transition:name` off anything a reveal can blank
   out — measure it: probe the incoming element's effective opacity at `pagereveal`, not just that
   the transition fired.
+
+    The **hero** could not be moved out of the way like that — it is the root snapshot. So the
+    inline script in `Layout.astro` marks a document entered through a transition with `vt-nav`, and
+    `:root.vt-nav header .aos` skips the reveal there. Without it the outgoing page's headline (at
+    full opacity) crossfades into this one's (at zero) and then fades in again, which reads as the
+    headline blanking out and restarting. `verify.mjs` asserts the rule still exists.
+
+- **The reveals are gated on `.js`**, added by that same inline script. `.aos` hides content in CSS
+  and reveals it with JavaScript, so ungating it means anyone whose script does not run gets a
+  permanently invisible page — the spec's own listed graceful-degradation mistake. `verify.mjs`
+  asserts every `.aos` hiding rule carries the gate and every page carries the bootstrap.
+- **Put both the property and the duration behind `motion-safe:`.** `transition-property`'s initial
+  value is `all`, so a bare `duration-1000` animates on its own: `motion-safe:transition-all` was
+  restating a default and gating nothing, and the reveals ran at full length under
+  `prefers-reduced-motion: reduce` for the whole life of the migration. Measure it in a browser
+  (`reducedMotion: 'reduce'` and count distinct opacity values) rather than reading the classes.
+- **A reveal must not start off-screen horizontally.** `aos-fade-left` used `translate-x-2/5` — 40%
+  of a full-width headline — which put the hero 86px past the viewport for the first ~280ms of
+  every load and flashed a horizontal scrollbar. Fixed offsets now, plus `overflow-x: clip` on
+  `html` as a guard. `body`'s `overflow-x: hidden` does **not** cover this; the document still
+  reported the overflow with it set.
 - **`aria-labelledby` on the repeated "Mehr erfahren" links lists the link's own id first**,
   then the card heading — `aria-labelledby="talk-x-more talk-x-title"`. The self-reference looks
   redundant and is not: naming the heading alone would drop the visible words "Mehr erfahren" out

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -20,6 +20,7 @@
  *   8. Document structure: one <main>, one <h1>, no skipped heading level, every
  *      link resolving to a non-empty accessible name, and no dangling
  *      aria-labelledby reference
+ *   9. Progressive enhancement: the reveals cannot outlive their JavaScript
  */
 
 import fs from 'node:fs';
@@ -460,6 +461,42 @@ console.log('\n8. Document structure');
     dangling === 0
         ? pass(`all ${references} aria-labelledby references resolve to an element on the page`)
         : fail(`${dangling}/${references} aria-labelledby references point at a missing id`);
+}
+
+// -------------------------------------------------- 9. progressive enhancement
+console.log('\n9. Progressive enhancement');
+{
+    // The reveals hide content in CSS and reveal it with JavaScript, which is only safe
+    // because the hidden state is gated on `.js` — set by an inline script in the head.
+    // Break either half and content disappears for anyone whose JS does not run, which
+    // no other check here can see.
+    const css = fs
+        .readdirSync(path.join(DIST, '_astro'))
+        .filter((f) => f.endsWith('.css'))
+        .map((f) => read(path.join(DIST, '_astro', f)))
+        .join('\n');
+
+    const missingBootstrap = pages.filter((f) => !read(f).includes("classList.add('js')"));
+    missingBootstrap.length === 0
+        ? pass(`all ${pages.length} pages carry the inline .js bootstrap`)
+        : fail(`${missingBootstrap.length} page(s) without the inline .js bootstrap: ${missingBootstrap[0]}`);
+
+    // Any rule that hides an .aos element must be behind the gate.
+    const ungated = [];
+    for (const m of css.matchAll(/([^{}]*\.aos[^{}]*)\{([^}]*)\}/g)) {
+        const [, selector, body] = m;
+        if (!/opacity:\s*0(?![.\d])/.test(body)) continue;
+        if (!selector.includes('.js ')) ungated.push(selector.trim().slice(0, 60));
+    }
+    ungated.length === 0
+        ? pass('every rule hiding an .aos element is gated on .js')
+        : fail(`${ungated.length} ungated .aos hiding rule(s): ${ungated.join(' | ')}`);
+
+    // Arriving through a view transition must skip the hero reveal, or the outgoing
+    // page's headline crossfades into an invisible one and appears to restart.
+    /\.vt-nav header \.aos/.test(css)
+        ? pass('the hero reveal is suppressed on view-transition navigations')
+        : fail('no .vt-nav rule — the hero will re-fade on every navigation');
 }
 
 console.log(`\n${failures === 0 ? 'PASS' : 'FAIL'} — ${checks} checks passed, ${failures} failure(s)\n`);

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -476,16 +476,29 @@ console.log('\n9. Progressive enhancement');
         .map((f) => read(path.join(DIST, '_astro', f)))
         .join('\n');
 
-    const missingBootstrap = pages.filter((f) => !read(f).includes("classList.add('js')"));
+    // Matched loosely on purpose: the exact quoting and spacing of the inline script is
+    // the minifier's business (compressHTML defaults to 'jsx'), not something this check
+    // should pin.
+    const BOOTSTRAP = /classList\s*\.\s*add\(\s*(['"`])js\1\s*\)/;
+    const missingBootstrap = pages.filter((f) => !BOOTSTRAP.test(read(f)));
     missingBootstrap.length === 0
         ? pass(`all ${pages.length} pages carry the inline .js bootstrap`)
         : fail(`${missingBootstrap.length} page(s) without the inline .js bootstrap: ${missingBootstrap[0]}`);
 
-    // Any rule that hides an .aos element must be behind the gate.
+    // Any rule that hides an .aos element must be behind the gate — and there is more
+    // than one way to hide: `opacity: 0` for the fades, `scale: 0` for aos-zoom-in, which
+    // collapses the element to a 0x0 box. (A translate only moves it, so it does not
+    // count.) Checking opacity alone is the same gap the forced-colors rule had.
+    // Tailwind compiles `scale-0` to `--tw-scale-x:0%` plus `scale:var(--tw-scale-x) …`,
+    // so the literal `scale:0` never appears — match the custom property instead. This
+    // check passed a mutated stylesheet until that was fixed.
+    const HIDES = /opacity:\s*0(?![.\d])|--tw-scale-[xy]:\s*0(?:%|px)?(?![.\d])/;
     const ungated = [];
     for (const m of css.matchAll(/([^{}]*\.aos[^{}]*)\{([^}]*)\}/g)) {
         const [, selector, body] = m;
-        if (!/opacity:\s*0(?![.\d])/.test(body)) continue;
+        if (!HIDES.test(body)) continue;
+        // The forced-colors block deliberately un-hides without a gate.
+        if (/forced-colors/.test(selector)) continue;
         if (!selector.includes('.js ')) ungated.push(selector.trim().slice(0, 60));
     }
     ungated.length === 0

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -31,7 +31,7 @@ const { title, subtitle, heroImage = pegelbar, heroName = 'hero-image' } = Astro
 
 <header class="bg-neutral relative h-svh md:h-auto" x-data="{ scrolledAway: false }">
     <div
-        class="fixed bg-tap-alpha-blue-light/80 dark:bg-tap-alpha-blue-dark/80 backdrop-blur-md w-full p-2 z-50"
+        class="site-bar fixed bg-tap-alpha-blue-light/80 dark:bg-tap-alpha-blue-dark/80 backdrop-blur-md w-full p-2 z-50"
         x-show="scrolledAway"
         x-transition:enter="transition ease-out duration-300 origin-top"
         x-transition:enter-start="opacity-0 -translate-y-12"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -43,6 +43,26 @@ const { heroTitle, heroSubtitle, heroImage, heroName = 'hero-image', ...seo } = 
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="theme-color" content="#3b5883" />
+        {
+            /*
+          Two lines that have to run before anything paints, so they are inline and
+          unbundled:
+
+          1. `vt-nav` marks a document that was entered through a cross-document view
+             transition. The hero reveal is suppressed in that case — the outgoing page's
+             headline is fully visible, the incoming one is captured at opacity 0, so the
+             crossfade reads as the headline blanking out and starting over. See aos.css.
+          2. `js` gates the reveals themselves. Hiding content in CSS and revealing it
+             with JavaScript leaves it hidden forever if the script never runs, so the
+             hidden state is only applied once this line has proven scripting works.
+        */
+        }
+        <script is:inline>
+            document.documentElement.classList.add('js');
+            addEventListener('pagereveal', (e) => {
+                if (e.viewTransition) document.documentElement.classList.add('vt-nav');
+            });
+        </script>
         <link rel="icon" href="/favicon.ico" sizes="48x48" type="image/x-icon" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/src/styles/aos.css
+++ b/src/styles/aos.css
@@ -1,13 +1,41 @@
+/*
+ * Scroll reveals. Alpine's x-intersect adds `.visible`; everything else is CSS.
+ *
+ * The hidden state is gated on `.js` (set by the inline script in Layout.astro), because
+ * an .aos element whose JavaScript never arrives would otherwise stay invisible for
+ * good — the failure mode The Website Specification calls out under graceful degradation.
+ * With no scripting the rules below never match and every element renders in its final
+ * state.
+ */
 @layer components {
-  .aos {
-    @apply transform opacity-0 duration-1000 motion-safe:transition-all;
+  .js .aos {
+    /*
+     * Both the property AND the duration have to sit behind motion-safe. The initial
+     * value of `transition-property` is `all`, so `duration-1000` on its own was enough
+     * to animate the reveal — `motion-safe:transition-all` only restated a default and
+     * gated nothing. Measured: with prefers-reduced-motion: reduce the opacity still
+     * ran through 48 distinct values. motion-reduce:transition-none makes the intent
+     * explicit rather than relying on a duration being absent.
+     */
+    @apply transform opacity-0;
+    @apply motion-safe:transition-all motion-safe:duration-1000 motion-reduce:transition-none;
 
     &.visible {
       @apply opacity-100;
     }
   }
 
-  .aos-fade-up {
+  /*
+   * Arriving through a view transition, the hero is already on screen: the outgoing
+   * page's headline is at full opacity and this one is snapshotted at zero, so playing
+   * the reveal on top of the crossfade looks like the headline blanking and restarting.
+   * Suppress it there and let the transition carry the motion. Cold loads keep the fade.
+   */
+  :root.vt-nav header .aos {
+    @apply translate-none opacity-100 transition-none;
+  }
+
+  .js .aos-fade-up {
     @apply translate-y-1/3;
 
     &.visible {
@@ -15,7 +43,7 @@
     }
   }
 
-  .aos-fade-down {
+  .js .aos-fade-down {
     @apply -translate-y-1/3;
 
     &.visible {
@@ -23,23 +51,29 @@
     }
   }
 
-  .aos-fade-left {
-    @apply translate-x-2/5;
+  /*
+   * Fixed offsets, not the percentage these two used to carry: 40% of a full-width
+   * headline pushed it 86px past the viewport for the first ~280ms of every page load,
+   * which flashed a horizontal scrollbar. `html { overflow-x: clip }` in site.css is the
+   * belt to this braces.
+   */
+  .js .aos-fade-left {
+    @apply translate-x-8;
 
     &.visible {
       @apply translate-x-0;
     }
   }
 
-  .aos-fade-right {
-    @apply -translate-x-2/5;
+  .js .aos-fade-right {
+    @apply -translate-x-8;
 
     &.visible {
       @apply translate-x-0;
     }
   }
 
-  .aos-zoom-in {
+  .js .aos-zoom-in {
     @apply scale-0;
 
     &.visible {

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -76,6 +76,17 @@
 @layer base {
   html {
     @apply scroll-smooth;
+
+    /* The sticky logo bar is `fixed` and ~56px tall, so an element scrolled to via
+       #content or any in-page anchor would otherwise land underneath it. */
+    scroll-padding-top: 4.5rem;
+
+    /* A reveal that starts off-screen must not be able to produce a horizontal
+       scrollbar. `clip` rather than `hidden`: it clips without creating a scroll
+       container, so it cannot become a scroll port and does not disturb the
+       document scroller or the view transitions. body's overflow-x: hidden does
+       not cover this — the document still reported 86px of overflow with it set. */
+    overflow-x: clip;
   }
 
   body {
@@ -84,6 +95,27 @@
 
   [x-cloak] {
     display: none !important;
+  }
+
+  /*
+   * Forced-colours mode replaces the palette wholesale, which takes the translucent
+   * sticky bar's background with it — leaving the logo floating over whatever is behind
+   * it. Give it a real border so it still reads as a bar, and make sure a reveal can
+   * never be the reason something is invisible here.
+   */
+  @media (forced-colors: active) {
+    /* System colours, so the bar survives the palette being replaced. `.site-bar` is a
+       plain hook on the element in Header.astro — the translucent tint and the blur both
+       disappear in this mode. */
+    .site-bar {
+      background: Canvas;
+      border-bottom: 1px solid CanvasText;
+    }
+
+    .aos {
+      opacity: 1 !important;
+      translate: none !important;
+    }
   }
 }
 

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -112,9 +112,15 @@
       border-bottom: 1px solid CanvasText;
     }
 
+    /* Every hiding mechanism the reveals use, not just opacity: `aos-fade-*` hides with
+       `translate`, `aos-zoom-in` with `scale-0` — and a scaled-to-zero element is a 0x0
+       box, so resetting opacity alone left the talk fact cards invisible. Measured: three
+       elements at scale 0 with this block already in place. */
     .aos {
       opacity: 1 !important;
       translate: none !important;
+      scale: none !important;
+      transition: none !important;
     }
   }
 }


### PR DESCRIPTION
Fixes #1485, and fixes the hero animation you reported. Three defects turned out to share one mechanism.

Everything below was **measured in a real browser**, not reasoned from the CSS — Playwright's MCP server would not connect this session, so `playwright-core` drove system Chrome from the scratchpad.

### 1. The hero fade "reset" — diagnosed

It is **not** the transition restarting. Listening from before any page script, `transitionrun` fires exactly once per load, with no `transitioncancel`. What actually happens on a cross-document navigation:

| | opacity |
|---|---|
| outgoing page's headline | 1.00 |
| incoming page's headline, when the transition snapshots it | **0.00** — Alpine has not fired `x-intersect` yet |

So the crossfade goes from a visible headline to an invisible one, and *then* the reveal fades it in over 1s. That reads exactly as "starts, resets, starts again".

This is the trap CLAUDE.md already documents, but the hero could not be dodged the way the cards were — it *is* the root snapshot. So the inline script marks a document entered through a transition with `vt-nav`, and `:root.vt-nav header .aos` skips the reveal there. Cold loads keep the fade, as you chose.

**Measured after the fix:** hero opacity `1.00` on the first frame after navigation and never dips; cold load still runs `0.00 → 1.00`.

### 2. An 86px horizontal scrollbar flash on every load

`aos-fade-left` used `translate-x-2/5` — 40% of the element's own width. On a full-width headline that put it **86px past the viewport for ~280ms**, 18 frames out of 150, on every page load. Only the hero used that class; everything else reveals vertically.

Fixed 2rem offsets now, plus `overflow-x: clip` on `html` as a guard against any future reveal doing the same. Worth noting: **`body`'s existing `overflow-x: hidden` did not prevent this** — the document still reported the overflow with it set, which I verified before and after.

**Measured after the fix:** 0 frames with overflow, vertical scrolling and the view transitions both unaffected by the clip.

### 3. #1485 proper — content invisible without JavaScript

`.aos` hid content in CSS and revealed it with Alpine, so a blocked or failed script left the hero headline, every card body and the talk fact cards invisible for good.

The hidden state is now gated on `.js`, set by the same inline script: **no script, no hiding.** That is stronger than `<noscript>`, which only covers JS being *disabled* — this also covers the script being blocked or erroring.

**Measured with `javaScriptEnabled: false`:** headline renders at 786×138 in its final position; `/talks` shows all 11 card bodies; screenshots attached to the issue thread.

### Found while measuring — worse than the reported bug

**The reveals animated at full length under `prefers-reduced-motion: reduce`.** `transition-property`'s initial value is `all`, so `duration-1000` sitting *outside* the `motion-safe:` variant was enough on its own — `motion-safe:transition-all` merely restated a default and gated nothing. This has been true since the migration.

Both now sit behind `motion-safe:`, with an explicit `motion-reduce:transition-none`. **Measured: 48 distinct opacity values under `reduce` before, 2 after** (i.e. it jumps to the final state).

My audit recorded `accessibility/reduced-motion` as **PASS** on a reading of the class names. That was wrong, and I have corrected the record on #1495.

### Also from #1485

- `scroll-padding-top: 4.5rem` on `html`, so an anchor target clears the fixed logo bar (`accessibility/focus-not-obscured`).
- A `@media (forced-colors: active)` block: the sticky bar gets real `Canvas`/`CanvasText` colours instead of a tint that mode discards, and no reveal can be the reason something is invisible (`accessibility/forced-colors`).

### Verification

`verify.mjs` gains section 9, 46 → **49 assertions**:

```
9. Progressive enhancement
  ✓ all 58 pages carry the inline .js bootstrap
  ✓ every rule hiding an .aos element is gated on .js
  ✓ the hero reveal is suppressed on view-transition navigations
```

Each proven to fail when mutated — bootstrap removed, gate stripped, `vt-nav` rule dropped — because a check that cannot fail is not a check. `pnpm check` 0 errors, `pnpm build` 58 pages, `pnpm verify` PASS.

The one thing I could not test: the inline script means a future CSP (#1487) needs a hash or nonce for it. That is the cost you accepted when picking this option, and it is now noted in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)