### PR TITLE
🔍 Keep the error page out of the index and say what happened

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ guidance.
 ```bash
 pnpm dev         # Astro dev server, http://localhost:4321
 pnpm build       # -> dist/
-pnpm verify      # assert dist/ is intact (49 assertions) — also a deploy gate
+pnpm verify      # assert dist/ is intact (52 assertions) — also a deploy gate
 pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (27 checks)
 pnpm check       # astro check
 pnpm preview     # serve dist/

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -21,6 +21,7 @@
  *      link resolving to a non-empty accessible name, and no dangling
  *      aria-labelledby reference
  *   9. Progressive enhancement: the reveals cannot outlive their JavaScript
+ *  10. Indexing policy: exactly one noindex page, and it is the error page
  */
 
 import fs from 'node:fs';
@@ -510,6 +511,32 @@ console.log('\n9. Progressive enhancement');
     /\.vt-nav header \.aos/.test(css)
         ? pass('the hero reveal is suppressed on view-transition navigations')
         : fail('no .vt-nav rule — the hero will re-fade on every navigation');
+}
+
+// ------------------------------------------------------- 10. indexing policy
+console.log('\n10. Indexing policy');
+{
+    // Every page states its policy explicitly, and exactly one page opts out: the error
+    // page. It shipped `index,follow` for the whole of the migration, because Seo.astro
+    // hardcoded the string with no way to override it.
+    const noindexed = pages.filter((f) => /<meta name="robots"[^>]*noindex/.test(read(f)));
+    const missing = pages.filter((f) => !/<meta name="robots"/.test(read(f)));
+    const expected = path.join(DIST, '404.html');
+
+    missing.length === 0
+        ? pass(`all ${pages.length} pages declare a robots policy`)
+        : fail(`${missing.length} page(s) with no robots meta: ${missing[0]}`);
+    noindexed.length === 1 && noindexed[0] === expected
+        ? pass('404.html is the only noindex page')
+        : fail(
+              noindexed.length === 0
+                  ? '404.html is indexable — nothing declares noindex'
+                  : `unexpected noindex pages: ${noindexed.filter((f) => f !== expected).join(', ') || '(404 missing from the list)'}`,
+          );
+    // The directory this referred to closed in 2017.
+    pages.every((f) => !read(f).includes('noodp'))
+        ? pass('no page still sends the dead noodp directive')
+        : fail('noodp is still being emitted');
 }
 
 console.log(`\n${failures === 0 ? 'PASS' : 'FAIL'} — ${checks} checks passed, ${failures} failure(s)\n`);

--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -31,9 +31,15 @@ export interface SeoProps {
     jsonLd?: Record<string, unknown> | null;
     /** Home shows the bare site title rather than "Page | Site". */
     isHome?: boolean;
+    /**
+     * Keep the page out of the index while still letting crawlers follow its links.
+     * Only 404.astro sets it: an error page that says `index` invites search engines to
+     * index a page whose whole job is to say the URL does not exist.
+     */
+    noindex?: boolean;
 }
 
-const { title, description, mainImage, jsonLd, isHome = false } = Astro.props as SeoProps;
+const { title, description, mainImage, jsonLd, isHome = false, noindex = false } = Astro.props as SeoProps;
 
 // `build.format: 'file'` puts ".html" into Astro.url.pathname, which would publish
 // canonical and og:url as "/impressum.html" — URLs that are not what is indexed.
@@ -60,7 +66,11 @@ const ogUrl = new URL(og.src, Astro.site).href;
 
 <title>{pageTitle}</title>
 
-<meta name="robots" content="index,follow,noodp" />
+{
+    /* `noodp` is gone: the Open Directory Project it referred to shut down in 2017, and
+    every engine dropped the directive with it. */
+}
+<meta name="robots" content={noindex ? 'noindex,follow' : 'index,follow'} />
 {description && <meta name="description" content={description} />}
 
 <meta property="og:title" content={isHome ? site.title : title} />

--- a/src/content/pages/error.mdx
+++ b/src/content/pages/error.mdx
@@ -1,5 +1,13 @@
 ---
-title: Fehler
+title: Seite nicht gefunden
 ---
 
-<p>Leider ist ein Fehler aufgetreten.</p>
+<p>Diese Seite gibt es nicht — vielleicht wurde sie verschoben, oder in der Adresse hat sich ein Tippfehler eingeschlichen.</p>
+<p>Weiter geht es hier:</p>
+
+<ul>
+<li><a href="/">Zur Startseite</a></li>
+<li><a href="/talks">Alle Talks</a></li>
+<li><a href="/persons">Alle Gäste</a></li>
+<li><a href="/kontakt">Kontakt</a></li>
+</ul>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,8 +4,13 @@
  *
  * Kirby served this at /error too, but with a 404 status — so /error was never a
  * usable URL despite being listed in the sitemap. Here it exists only as 404.html,
- * wired up via ErrorDocument in the deployed .htaccess, and is kept out of the
- * sitemap.
+ * wired up via `not_found_handling: "404-page"` in wrangler.jsonc, which serves it with
+ * a real 404 status, and it is kept out of the sitemap.
+ *
+ * `noindex` because everything else defaults to index: a page whose job is to say a URL
+ * does not exist has no business in an index. There is no 500 counterpart — this is a
+ * static-assets deploy with no Worker in the request path, so Cloudflare's own 5xx page
+ * is what renders and nothing in this repo can change it.
  */
 import { getEntry, render } from 'astro:content';
 import Layout from '../layouts/Layout.astro';
@@ -15,7 +20,7 @@ if (!page) throw new Error('content/pages/error.mdx is missing');
 const { Content } = await render(page);
 ---
 
-<Layout title={page.data.title}>
+<Layout title={page.data.title} noindex>
     <section class="blocks container mx-auto my-16 px-6">
         <Content />
     </section>


### PR DESCRIPTION
Fixes #1483. Two **required** items, both about the 404: [`seo/meta-robots`](https://specification.website/spec/seo/meta-robots/) and [`resilience/error-pages`](https://specification.website/spec/resilience/error-pages/).

### The error page was inviting indexation

`Seo.astro:63` hardcoded `index,follow,noodp` on every page with no override, so `dist/404.html` shipped:

```html
<meta name="robots" content="index,follow,noodp">
```

A page whose entire job is to report that a URL does not exist was telling search engines to index it. `SeoProps` gains a `noindex` prop, `404.astro` sets it, nothing else does:

```html
<!-- 404.html -->      <meta name="robots" content="noindex,follow">
<!-- every other -->   <meta name="robots" content="index,follow">
```

`noodp` goes at the same time — the Open Directory Project it referred to shut down in 2017 and every engine dropped the directive with it.

### The copy was generic

"Leider ist ein Fehler aufgetreten" describes any error and offers no way onward. It now says the page does not exist, allows for a typo in the address, and links to the home page, the talks, the guests and the contact page. The title changes with it, so the page announces **"Seite nicht gefunden"** instead of "Fehler".

What already passed and is unchanged: `wrangler.jsonc`'s `not_found_handling: "404-page"` serves it with a real 404 status, which `verify-live.sh` checks.

### No 500 page — assessed, not skipped

This is a static-assets deploy with no Worker in the request path, so Cloudflare's own 5xx page renders and nothing in this repo can reach it. That is now written in `404.astro`'s header comment, and the issue closes that sub-item as assessed rather than leaving it looking undone.

### Verification

`verify.mjs` gains section 10, 49 → **52 assertions**:

```
10. Indexing policy
  ✓ all 58 pages declare a robots policy
  ✓ 404.html is the only noindex page
  ✓ no page still sends the dead noodp directive
```

The middle one is the interesting check: it fails both if the 404 becomes indexable *and* if any content page accidentally gains `noindex` — the mistake that silently de-indexes a live page, which this repo's whole URL-parity invariant exists to prevent. Proven by mutation:

| mutation | result |
|---|---|
| 404 back to `index,follow` | ✗ `404.html is indexable — nothing declares noindex` |
| `/talks` given `noindex` | ✗ `unexpected noindex pages: dist/talks.html` |
| `noodp` reintroduced | ✗ `noodp is still being emitted` |

`pnpm check` 0 errors, `pnpm build` 58 pages, `pnpm verify` PASS. The live 404 check in `verify-live.sh` greps for the site branding, which the new title still carries, so it keeps passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)