### PR TITLE
🎨 Fix the accent contrast without touching the brand red

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ guidance.
 ```bash
 pnpm dev         # Astro dev server, http://localhost:4321
 pnpm build       # -> dist/
-pnpm verify      # assert dist/ is intact (52 assertions) — also a deploy gate
+pnpm verify      # assert dist/ is intact (54 assertions) — also a deploy gate
 pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (27 checks)
 pnpm check       # astro check
 pnpm preview     # serve dist/
@@ -158,6 +158,25 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   every load and flashed a horizontal scrollbar. Fixed offsets now, plus `overflow-x: clip` on
   `html` as a guard. `body`'s `overflow-x: hidden` does **not** cover this; the document still
   reported the overflow with it set.
+- **The accent is a fill colour, not a text colour.** `--color-accent` is the brand red and is
+  deliberately unchanged; white on it measures **3.29:1**, which fails AA for every button label
+  here (18px, weight 500 — the large-text exemption needs 18.66px _and_ bold). So
+  `--color-accent-content` is the dark base-content instead: 5.39:1, dark-on-coral. Soft buttons
+  take their text from `--btn-color`, not `--btn-fg`, so that change does not reach them —
+  `--color-accent-strong` exists for that one case (accent on its own 10% tint was 2.82:1, the
+  worst pairing on the site; the darker red reads 5.26:1). `verify.mjs` asserts the label token
+  stays dark and that accent-strong stays darker than the accent.
+- **Do not measure contrast by overriding a token at runtime.** FlyOnUI derives button colours
+  through registered custom properties and `color-mix()`, which Chrome resolves eagerly: injecting
+  a new `--color-accent` moves the solid button and leaves the soft variant frozen at the old
+  value, so a sweep of candidate colours silently reports the same number for every one of them.
+  Change the token in `site.css`, rebuild, and measure the built output. Also note computed colours
+  come back as `oklch()`/`oklab()` now, so parsing `rgb(...)` finds nothing — rasterise through a
+  canvas instead.
+- **Opacity-suffixed text below `/65` fails AA.** `text-base-content/50` measured 3.31:1 and
+  `text-neutral/50` 3.07:1 on the page background; `/60` scrapes 4.51 and `/65` gives 4.74. Icons
+  at `/50` are fine — non-text contrast only needs 3:1 — which is why `Person.astro`'s socials and
+  the ticket glyph keep theirs.
 - **`aria-labelledby` on the repeated "Mehr erfahren" links lists the link's own id first**,
   then the card heading — `aria-labelledby="talk-x-more talk-x-title"`. The self-reference looks
   redundant and is not: naming the heading alone would drop the visible words "Mehr erfahren" out

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -22,6 +22,8 @@
  *      aria-labelledby reference
  *   9. Progressive enhancement: the reveals cannot outlive their JavaScript
  *  10. Indexing policy: exactly one noindex page, and it is the error page
+ *  11. Contrast tokens: the label on the accent stays dark, accent-strong stays
+ *      darker than the accent
  */
 
 import fs from 'node:fs';
@@ -537,6 +539,42 @@ console.log('\n10. Indexing policy');
     pages.every((f) => !read(f).includes('noodp'))
         ? pass('no page still sends the dead noodp directive')
         : fail('noodp is still being emitted');
+}
+
+// ------------------------------------------------------- 11. contrast tokens
+console.log('\n11. Contrast tokens');
+{
+    // Contrast itself needs a browser — these are the two token invariants the measured
+    // ratios rest on, so a change that would quietly reintroduce a 3.29:1 button fails
+    // here instead. The accent FILL is deliberately unconstrained: it is the brand
+    // colour and it only has to clear the 3:1 non-text bar.
+    const css = fs
+        .readdirSync(path.join(DIST, '_astro'))
+        .filter((f) => f.endsWith('.css'))
+        .map((f) => read(path.join(DIST, '_astro', f)))
+        .join('\n');
+
+    // oklch lightness, written either as a percentage or a 0-1 number
+    const lightness = (token) => {
+        const m = css.match(new RegExp(`${token}:\\s*oklch\\(\\s*([0-9.]+)(%?)`));
+        if (!m) return null;
+        return m[2] === '%' ? Number(m[1]) / 100 : Number(m[1]);
+    };
+
+    const content = lightness('--color-accent-content');
+    const accent = lightness('--color-accent');
+    const strong = lightness('--color-accent-strong');
+
+    content !== null && content < 0.5
+        ? pass(`the label on the accent is dark (L=${content})`)
+        : fail(
+              content === null
+                  ? '--color-accent-content not found'
+                  : `--color-accent-content is light (L=${content}) — white on this accent measures 3.29:1`,
+          );
+    strong !== null && accent !== null && strong < accent
+        ? pass(`--color-accent-strong is darker than the accent (L=${strong} < ${accent})`)
+        : fail('--color-accent-strong is missing or not darker than --color-accent');
 }
 
 console.log(`\n${failures === 0 ? 'PASS' : 'FAIL'} — ${checks} checks passed, ${failures} failure(s)\n`);

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -554,9 +554,25 @@ console.log('\n11. Contrast tokens');
         .map((f) => read(path.join(DIST, '_astro', f)))
         .join('\n');
 
+    // The declared value of a custom property, following `var(--other)` aliases so a
+    // token defined by reference — the tempting way to write accent-content, since it is
+    // literally base-content — still resolves instead of reading as missing.
+    const declared = (token, seen = new Set()) => {
+        if (seen.has(token)) return null; // a cycle in the CSS, not our problem to resolve
+        seen.add(token);
+        const name = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const m = css.match(new RegExp(`${name}:\\s*([^;}]+)`));
+        if (!m) return null;
+        const value = m[1].trim();
+        const alias = value.match(/^var\(\s*(--[\w-]+)\s*(?:,\s*([^)]*))?\)$/);
+        if (!alias) return value;
+        return declared(alias[1], seen) ?? alias[2]?.trim() ?? null;
+    };
+
     // oklch lightness, written either as a percentage or a 0-1 number
     const lightness = (token) => {
-        const m = css.match(new RegExp(`${token}:\\s*oklch\\(\\s*([0-9.]+)(%?)`));
+        const value = declared(token);
+        const m = value?.match(/^oklch\(\s*([0-9.]+)(%?)/);
         if (!m) return null;
         return m[2] === '%' ? Number(m[1]) / 100 : Number(m[1]);
     };

--- a/src/pages/talks/[slug].astro
+++ b/src/pages/talks/[slug].astro
@@ -237,7 +237,7 @@ const jsonLd = eventSchema({
                         <a href={`/talks/${prev.id}`} rel="prev" class="btn btn-neutral/80 btn-text btn-xl text-left">
                             <Icon name="ri:arrow-left-s-line" class="size-12 shrink-0" />
                             <div>
-                                <span class="text-neutral/50 block text-sm font-medium uppercase">{prev.data.textline}</span>
+                                <span class="text-neutral/70 block text-sm font-medium uppercase">{prev.data.textline}</span>
                                 <span class="sr-only">:</span>
                                 <span>{prev.data.title}</span>
                             </div>
@@ -252,7 +252,7 @@ const jsonLd = eventSchema({
                     <div class="p-2 text-right">
                         <a href={`/talks/${next.id}`} rel="next" class="btn btn-neutral/80 btn-text btn-xl text-right">
                             <div>
-                                <span class="text-neutral/50 block text-sm font-medium uppercase">{next.data.textline}</span>
+                                <span class="text-neutral/70 block text-sm font-medium uppercase">{next.data.textline}</span>
                                 <span class="sr-only">:</span>
                                 <span>{next.data.title}</span>
                             </div>

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -77,10 +77,10 @@ const description = 'Alle Ausgaben der Talk-Reihe Talk am Pegel in Neuss.';
                                         :class="visible && 'visible'"
                                     >
                                         <h2 class="card-title text-lg">
-                                            <div class="text-base-content/65 text-sm">
+                                            <span class="text-base-content/65 block text-sm">
                                                 {talk.data.textline}
                                                 <span class="sr-only">:</span>
-                                            </div>
+                                            </span>
                                             <span id={`talk-${talk.id}-title`}>{talk.data.title}</span>
                                         </h2>
 

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -49,7 +49,7 @@ const description = 'Alle Ausgaben der Talk-Reihe Talk am Pegel in Neuss.';
                                     'me-4 ms-1 mt-3 max-md:pt-2',
                                 ]}
                             >
-                                <time class="text-base-content/50 text-sm font-normal">
+                                <time class="text-base-content/65 text-sm font-normal">
                                     {formatDate(talk.data.date)}
                                 </time>
                             </div>
@@ -77,7 +77,7 @@ const description = 'Alle Ausgaben der Talk-Reihe Talk am Pegel in Neuss.';
                                         :class="visible && 'visible'"
                                     >
                                         <h2 class="card-title text-lg">
-                                            <div class="text-base-content/50 text-sm">
+                                            <div class="text-base-content/65 text-sm">
                                                 {talk.data.textline}
                                                 <span class="sr-only">:</span>
                                             </div>

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -30,8 +30,27 @@
   --color-primary-content: oklch(100% 0 0);
   --color-secondary: oklch(0.81 0.1381 70.94);
   --color-secondary-content: oklch(0% 0 0);
+  /*
+   * The brand red is unchanged. What changed is the label ON it: white measured 3.29:1
+   * against this colour, which fails AA for anything but large text, and every button
+   * label here is 18px at weight 500. The dark base-content reads 5.39:1 on the same
+   * fill, so the buttons are dark-on-coral now and the brand colour is untouched
+   * everywhere it appears.
+   *
+   * The accent as a fill still passes non-text contrast against the page (3.12:1
+   * against base-200, measured) — thin, so darkening the page or lightening the accent
+   * would need re-measuring.
+   */
   --color-accent: oklch(0.67 0.2013 24.29);
-  --color-accent-content: oklch(100% 0 0);
+  --color-accent-content: oklch(21% 0.006 285.885);
+
+  /*
+   * Soft buttons take their TEXT colour from the accent itself rather than from
+   * accent-content, so the change above does not reach them: accent on its own 10% tint
+   * measured 2.82:1, the worst pairing on the site. This darker red is for that case
+   * only — 5.26:1 on the same tint. Do not use it for fills.
+   */
+  --color-accent-strong: oklch(0.52 0.2013 24.29);
   --color-neutral: oklch(27% 0.006 286.033);
   --color-neutral-content: oklch(98% 0 0);
   --color-info: oklch(74% 0.16 232.661);
@@ -132,6 +151,14 @@
    The paired elements are named with Astro's `transition:name` directive, which emits
    nothing but a `view-transition-name` rule — see Header/Person/LatestEvent and the
    talks templates. */
+/* Unlayered on purpose: FlyOnUI's own `.btn-soft { color: var(--btn-color) }` lives in a
+   layer, and an unlayered rule beats every layer regardless of source order. Setting
+   --btn-color rather than `color` also carries the darker red into the 10% background
+   mix, so the tint deepens with the text and the pairing stays balanced. */
+.btn-soft.btn-accent {
+  --btn-color: var(--color-accent-strong);
+}
+
 @view-transition {
   navigation: auto;
 }


### PR DESCRIPTION
Fixes #1481 — the last P0, and the one that needed your decision. [`accessibility/color-contrast`](https://specification.website/spec/accessibility/color-contrast/), required.

### What was actually failing

Measured on the built site with every element's real composited background, not computed from tokens:

| pairing | before | need |
|---|---|---|
| white on accent (every button label) | **3.29** | 4.5 |
| soft-accent button text on its own 10% tint | **2.82** | 4.5 |
| `text-base-content/50` | **3.31** | 4.5 |
| `text-neutral/50` | **3.07** | 4.5 |
| accent fill vs page (non-text) | 3.12 | 3.0 ✓ |

The button labels are 18px at weight 500, so the large-text exemption does not apply — that needs 18.66px **and** bold.

### The fix: the red stays, the label moves

`--color-accent` is **unchanged**. `--color-accent-content` goes from white to the dark base-content: **5.39:1** on the identical fill. The brand red is pixel-identical everywhere it appears; the buttons now read dark-on-coral.

Soft buttons take their text from `--btn-color`, not `--btn-fg`, so that change does not reach them. `--color-accent-strong` (a darker red) covers that one case at **5.03:1** measured, applied through an unlayered `.btn-soft.btn-accent` rule — unlayered because FlyOnUI's own `.btn-soft { color: var(--btn-color) }` sits in a layer, and setting `--btn-color` rather than `color` carries the darker red into the 10% background mix so text and tint move together.

Muted text raised to `/65` and `/70` (4.74 and 5.54). Only the four instances that are genuinely text — the `/50` **icons** in `Person.astro` and the ticket glyph keep theirs, since non-text contrast only needs 3:1 and they measure 3.31.

### Verification

A sweep of every text-bearing element across five pages, compositing each one's actual background stack:

```
205 text elements measured; 56 sit over a background image (reported separately)
33 of 149 on solid backgrounds fall below their threshold     ← before
 0 of 149 on solid backgrounds fall below their threshold     ← after
```

Ratios after, on the built output: solid button **5.39**, soft button **5.03**, primary button 5.07, muted text 4.74–5.54, accent fill 3.12 (unchanged, still clears the non-text bar).

`verify.mjs` gains section 11, 52 → **54**: the accent label token stays dark, and accent-strong stays darker than the accent. Contrast itself needs a browser, but those are the invariants the measured ratios rest on — confirmed the first one fails when the label reverts to white.

### Two traps, now commented in the source

Both cost me real time and would cost the next person the same:

1. **A runtime token override cannot be used to measure this.** Chrome resolves FlyOnUI's `color-mix()` through registered custom properties eagerly, so injecting a candidate `--color-accent` moved the solid button and left the soft variant **frozen at the old value** — my first sweep reported an identical `2.82` for all six candidates and looked like a CSS finding. The honest method is: change the token in `site.css`, rebuild, measure the built output.
2. **Computed colours come back as `oklch()`/`oklab()`** now that the theme authors them that way, so a parser looking for `rgb(...)` silently finds nothing — my first contrast audit "found" 5 elements on 5 pages. Rasterising the colour through a canvas handles any syntax.

Both are why the numbers in the issue were token arithmetic and the numbers here are measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)