### PR TITLE
🏷️ Describe the pages Kirby left bare

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,21 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   every load and flashed a horizontal scrollbar. Fixed offsets now, plus `overflow-x: clip` on
   `html` as a guard. `body`'s `overflow-x: hidden` does **not** cover this; the document still
   reported the overflow with it set.
+- **`Seo.astro` takes one JSON-LD node or an array of them**, emitting one `<script>` per node
+  rather than a single array-valued block. On a talk page the **Event must come first**:
+  `verify.mjs` reads the first block for its Event completeness checks and for the past-event
+  `SoldOut` assertion, both of which bail out if it is not an Event.
+- **Section 4's presence map is now positive, and derived.** It used to assert that `/talks`,
+  `/persons` and the 40 person pages carried _no_ JSON-LD, because Kirby emitted none and the
+  migration matched it. Those pages now carry `Person`, `CollectionPage`/`ItemList` and
+  `BreadcrumbList`, and the counts come from the page inventory rather than literals — so adding
+  a talk or a person does not require editing a number. `/404` is the one page that should carry
+  nothing, and that is asserted.
+- **The `BreadcrumbList` has no visible trail to match, by decision.** The spec wants both and
+  lists a disagreement between them as a mistake; with no trail there is nothing to disagree
+  with, but this is still half the item, chosen deliberately over a visual change to 51 pages.
+  If a visible breadcrumb is ever added it must match the JSON-LD exactly — same items, same
+  order, same names, same URLs — and the current page must not link to itself.
 - **`color-scheme` is already set in CSS — the theme block is not dead.** FlyOnUI compiles the
   `tap` theme to `:where(:root),:root:has(input.theme-controller[value=tap]:checked),[data-theme=tap]`,
   and the leading `:where(:root)` is what makes it apply: every colour token and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,11 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   every load and flashed a horizontal scrollbar. Fixed offsets now, plus `overflow-x: clip` on
   `html` as a guard. `body`'s `overflow-x: hidden` does **not** cover this; the document still
   reported the overflow with it set.
+- **JSON-LD goes out through `set:html`, so `<` must stay escaped.** `JSON.stringify` does not
+  escape it, and a value containing `</script>` would close the block and turn the rest into
+  markup. `Seo.astro` replaces `<` with `\u003c` — byte-identical data to a consumer — and
+  `verify.mjs` fails if any emitted block contains a literal `<`. The values come from content,
+  so the day one of them holds a tag is the day nobody is watching.
 - **`Seo.astro` takes one JSON-LD node or an array of them**, emitting one `<script>` per node
   rather than a single array-valued block. On a talk page the **Event must come first**:
   `verify.mjs` reads the first block for its Event completeness checks and for the past-event

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -12,8 +12,8 @@
  *   1. URL inventory matches the expected public URL list exactly
  *   2. Every internal link and asset reference resolves to a built file
  *   3. HTML sanity: tag balance, no nested anchors, no invalid nesting
- *   4. JSON-LD parses, the per-page presence map matches Kirby's, and no past event
- *      still advertises tickets
+ *   4. JSON-LD parses, every page type carries the nodes it should, and no past
+ *      event still advertises tickets
  *   5. canonical/og:url are extensionless and absolute
  *   6. German date formatting is present where expected
  *   7. Images: every <img> has alt and intrinsic dimensions, and the hero is not lazy
@@ -271,12 +271,48 @@ console.log('\n4. JSON-LD');
     const expect = { Event: 11, WebSite: 1, ContactPage: 1, WebPage: 2 };
     for (const [t, n] of Object.entries(expect)) count(t) === n ? pass(`${n}× ${t}`) : fail(`expected ${n}× ${t}, found ${count(t)}`);
 
-    // Kirby emitted none on these; confirm we match.
-    const shouldHaveNone = [...seen].filter(([u]) => u === '/talks' || u === '/persons' || u.startsWith('/persons/') || u === '/404');
-    const wrong = shouldHaveNone.filter(([, t]) => t.length > 0).map(([u]) => u);
-    wrong.length === 0
-        ? pass(`no JSON-LD on the ${shouldHaveNone.length} pages Kirby left bare`)
-        : fail(`unexpected JSON-LD on: ${wrong.join(', ')}`);
+    // The presence map used to assert the OPPOSITE of this: /talks, /persons and the 40
+    // person pages had no JSON-LD because Kirby emitted none, and the migration matched
+    // that faithfully. #1489 filled the gap, so the assertion is now positive — and
+    // derived from the page inventory rather than hardcoded, so adding a talk or a person
+    // does not require editing a number here.
+    const personPages = [...seen].filter(([u]) => u.startsWith('/persons/'));
+    const talkPages = [...seen].filter(([u]) => u.startsWith('/talks/'));
+
+    const personMissing = personPages.filter(([, t]) => !t.includes('Person')).map(([u]) => u);
+    personMissing.length === 0
+        ? pass(`Person schema on all ${personPages.length} person pages`)
+        : fail(`${personMissing.length} person page(s) without Person: ${personMissing.slice(0, 3).join(', ')}`);
+
+    const crumbless = [...personPages, ...talkPages].filter(([, t]) => !t.includes('BreadcrumbList')).map(([u]) => u);
+    crumbless.length === 0
+        ? pass(`BreadcrumbList on all ${personPages.length + talkPages.length} detail pages`)
+        : fail(`${crumbless.length} detail page(s) without BreadcrumbList: ${crumbless.slice(0, 3).join(', ')}`);
+
+    // The index pages exist to present a list, so the list has to be in the node — and
+    // as long as the page count, since an ItemList that silently drops entries is worse
+    // than none.
+    for (const [url, expectedCount] of [
+        ['/talks', talkPages.length],
+        ['/persons', personPages.length],
+    ]) {
+        const file = pages.find((f) => toUrl(f) === url);
+        const nodes = [...read(file).matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)].map((m) => JSON.parse(m[1]));
+        const collection = nodes.find((n) => n['@type'] === 'CollectionPage');
+        const list = collection?.mainEntity;
+        if (!collection) fail(`${url} has no CollectionPage node`);
+        else if (list?.['@type'] !== 'ItemList') fail(`${url}: CollectionPage.mainEntity is not an ItemList`);
+        else if (list.itemListElement?.length !== expectedCount)
+            fail(`${url}: ItemList holds ${list.itemListElement?.length} of ${expectedCount} entries`);
+        else pass(`${url} lists all ${expectedCount} entries as an ItemList`);
+    }
+
+    // /404 is the one page that should carry nothing: it is noindex, so there is no
+    // consumer to describe it to.
+    const bare = [...seen].filter(([, t]) => t.length === 0).map(([u]) => u);
+    bare.length === 1 && bare[0] === '/404'
+        ? pass('/404 is the only page without JSON-LD')
+        : fail(`pages without JSON-LD: ${bare.join(', ') || '(none — /404 gained some?)'}`);
 
     // Event schema completeness
     const talkFile = pages.find((f) => toUrl(f).startsWith('/talks/'));

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -267,6 +267,21 @@ console.log('\n4. JSON-LD');
     }
     if (!unparseable) pass('every JSON-LD block parses');
 
+    // The blocks go out through set:html, and JSON.stringify does not escape `<` — so a
+    // value containing `</script>` would close the block and the rest would be parsed as
+    // markup. Seo.astro escapes it to \u003c; this asserts the escaping is still there,
+    // since the values come from content and the day one of them contains a tag is the
+    // day nobody is looking.
+    const unescaped = [];
+    for (const f of pages) {
+        for (const m of read(f).matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)) {
+            if (m[1].includes('<')) unescaped.push(toUrl(f));
+        }
+    }
+    unescaped.length === 0
+        ? pass('no JSON-LD block contains an unescaped <')
+        : fail(`${unescaped.length} JSON-LD block(s) with a literal <: ${[...new Set(unescaped)].slice(0, 3).join(', ')}`);
+
     const count = (t) => [...seen.values()].filter((v) => v.includes(t)).length;
     const expect = { Event: 11, WebSite: 1, ContactPage: 1, WebPage: 2 };
     for (const [t, n] of Object.entries(expect)) count(t) === n ? pass(`${n}× ${t}`) : fail(`expected ${n}× ${t}, found ${count(t)}`);

--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -27,8 +27,15 @@ export interface SeoProps {
     description?: string;
     /** Social image source. Falls back to the site banner, as Kirby's config did. */
     mainImage?: ImageMetadata;
-    /** Rendered into <script type="application/ld+json">. Omit for no JSON-LD. */
-    jsonLd?: Record<string, unknown> | null;
+    /**
+     * Rendered into <script type="application/ld+json">. Omit for no JSON-LD.
+     *
+     * An array emits one script tag per node rather than a single array-valued block:
+     * both are valid JSON-LD, but one node per block keeps each type independently
+     * greppable, and verify.mjs reads the FIRST block on a talk page for its Event
+     * assertions — so pass the Event first there.
+     */
+    jsonLd?: Record<string, unknown> | Record<string, unknown>[] | null;
     /** Home shows the bare site title rather than "Page | Site". */
     isHome?: boolean;
     /**
@@ -91,4 +98,9 @@ const ogUrl = new URL(og.src, Astro.site).href;
 
 <link rel="canonical" href={canonical} />
 
-{jsonLd && <script type="application/ld+json" set:html={JSON.stringify(jsonLd, null, 4)} is:inline />}
+{
+    jsonLd &&
+        (Array.isArray(jsonLd) ? jsonLd : [jsonLd]).map((node) => (
+            <script type="application/ld+json" set:html={JSON.stringify(node, null, 4)} is:inline />
+        ))
+}

--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -69,6 +69,16 @@ const og = await getImage({
     quality: 85,
 });
 const ogUrl = new URL(og.src, Astro.site).href;
+
+/**
+ * JSON.stringify does not escape `<`, and this goes out through set:html — so a value
+ * containing `</script>` would close the block early and everything after it would be
+ * parsed as markup. Every value here comes from the content collections, which is to say
+ * from a pull request rather than from a stranger, but "the CMS is the repo" is not a
+ * reason to leave an unescaped sink. `\u003c` is valid inside a JSON string and parses
+ * back to `<`, so consumers see byte-identical data.
+ */
+const ldJson = (node: unknown) => JSON.stringify(node, null, 4).replace(/</g, '\\u003c');
 ---
 
 <title>{pageTitle}</title>
@@ -100,7 +110,5 @@ const ogUrl = new URL(og.src, Astro.site).href;
 
 {
     jsonLd &&
-        (Array.isArray(jsonLd) ? jsonLd : [jsonLd]).map((node) => (
-            <script type="application/ld+json" set:html={JSON.stringify(node, null, 4)} is:inline />
-        ))
+        (Array.isArray(jsonLd) ? jsonLd : [jsonLd]).map((node) => <script type="application/ld+json" set:html={ldJson(node)} is:inline />)
 }

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -72,9 +72,26 @@ export function person(opts: {
     };
 }
 
-/** Index pages: the page itself, plus the list it exists to present. */
-export function collectionPage(opts: { name: string; url: string; description: string; items: { name: string; url: string }[] }) {
-    const { name, url, description, items } = opts;
+/**
+ * Index pages: the page itself, plus the list it exists to present.
+ *
+ * Each ListItem wraps a TYPED `item` rather than carrying a bare `url`. Google documents
+ * both shapes — a summary-page carousel puts `url` on the ListItem, an all-in-one page
+ * nests an `item` — but carousel rich results are limited to Recipe/Movie/Course/
+ * Restaurant, so neither of these lists is eligible either way. What is left is which
+ * shape says more: `item` is the schema.org property for "the thing being listed", it is
+ * what Google's event-listing guidance wants on a page listing events, and it carries a
+ * type, so a consumer learns "this entry is an Event called X" rather than just a URL.
+ * `startDate` rides along where the collection has one.
+ */
+export function collectionPage(opts: {
+    name: string;
+    url: string;
+    description: string;
+    itemType: 'Event' | 'Person';
+    items: { name: string; url: string; startDate?: string }[];
+}) {
+    const { name, url, description, itemType, items } = opts;
     // No `image`: Seo.astro already declares the social image as meta tags, and repeating
     // it inside the node tells a consumer nothing new.
     return {
@@ -87,11 +104,15 @@ export function collectionPage(opts: { name: string; url: string; description: s
         mainEntity: {
             '@type': 'ItemList',
             numberOfItems: items.length,
-            itemListElement: items.map((item, i) => ({
+            itemListElement: items.map((entry, i) => ({
                 '@type': 'ListItem',
                 position: i + 1,
-                name: item.name,
-                url: item.url,
+                item: {
+                    '@type': itemType,
+                    name: entry.name,
+                    url: entry.url,
+                    ...(entry.startDate ? { startDate: entry.startDate } : {}),
+                },
             })),
         },
     };

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -42,6 +42,83 @@ export function contactPage(name: string, url: string, image: string) {
     return { '@context': CONTEXT, '@type': 'ContactPage', name, url, inLanguage: 'de_DE', image };
 }
 
+/**
+ * Person, for the 40 detail pages. Kirby emitted nothing here; the talk pages already
+ * describe these people as an Event's `performer`, so this is the same subject getting a
+ * node of its own with the links the content collection actually holds.
+ *
+ * `image` must be a DERIVED image, never `mainImage.src` — that is the untouched original
+ * and this is exactly where 10.8 MB of them ended up being advertised before. verify.mjs
+ * fails on any JSON-LD image over 400 kB.
+ */
+export function person(opts: {
+    name: string;
+    jobTitle: string;
+    url: string;
+    image: string | null;
+    sameAs: string[];
+    performerIn: { name: string; url: string }[];
+}) {
+    const { name, jobTitle, url, image, sameAs, performerIn } = opts;
+    return {
+        '@context': CONTEXT,
+        '@type': 'Person',
+        name,
+        jobTitle,
+        url,
+        ...(image ? { image } : {}),
+        ...(sameAs.length ? { sameAs } : {}),
+        ...(performerIn.length ? { performerIn: performerIn.map((e) => ({ '@type': 'Event', name: e.name, url: e.url })) } : {}),
+    };
+}
+
+/** Index pages: the page itself, plus the list it exists to present. */
+export function collectionPage(opts: { name: string; url: string; description: string; items: { name: string; url: string }[] }) {
+    const { name, url, description, items } = opts;
+    // No `image`: Seo.astro already declares the social image as meta tags, and repeating
+    // it inside the node tells a consumer nothing new.
+    return {
+        '@context': CONTEXT,
+        '@type': 'CollectionPage',
+        name,
+        url,
+        description,
+        inLanguage: 'de_DE',
+        mainEntity: {
+            '@type': 'ItemList',
+            numberOfItems: items.length,
+            itemListElement: items.map((item, i) => ({
+                '@type': 'ListItem',
+                position: i + 1,
+                name: item.name,
+                url: item.url,
+            })),
+        },
+    };
+}
+
+/**
+ * BreadcrumbList for the two detail page types.
+ *
+ * DELIBERATE DEVIATION, decided by the site owner: there is no visible breadcrumb trail
+ * to match this. The spec wants both and lists "visible trail and JSON-LD list disagree"
+ * as a mistake — with no trail at all there is nothing to disagree with, but this is
+ * still half of what it asks for. The hierarchy itself is honest: it mirrors the URL
+ * structure rather than any click path.
+ */
+export function breadcrumbList(items: { name: string; url: string }[]) {
+    return {
+        '@context': CONTEXT,
+        '@type': 'BreadcrumbList',
+        itemListElement: items.map((item, i) => ({
+            '@type': 'ListItem',
+            position: i + 1,
+            name: item.name,
+            item: item.url,
+        })),
+    };
+}
+
 export interface PerformerInput {
     name: string;
     jobTitle: string;

--- a/src/pages/persons/[slug].astro
+++ b/src/pages/persons/[slug].astro
@@ -12,13 +12,18 @@
  * This renders the card, as decided during planning. Expect the person pages to have
  * MORE content than the parity baseline.
  *
- * Kirby emitted neither a description nor JSON-LD for this template.
+ * Kirby emitted neither a description nor JSON-LD for this template. The description was
+ * added during the migration; the JSON-LD is added here (#1489) — these people are
+ * already described as an Event's `performer` on the talk pages, so the detail page
+ * carrying nothing was the odd one out.
  */
 import { Icon } from 'astro-icon/components';
+import { getImage } from 'astro:assets';
 import Layout from '../../layouts/Layout.astro';
 import Person from '../../components/Person.astro';
 import { persons, talksOf } from '../../lib/content';
 import { formatDate } from '../../lib/dates';
+import { person as personSchema, breadcrumbList } from '../../lib/jsonld';
 
 export async function getStaticPaths() {
     const all = await persons();
@@ -28,9 +33,39 @@ export async function getStaticPaths() {
 const { person } = Astro.props;
 const talks = await talksOf(person.id);
 const description = `${person.data.title} — ${person.data.subHeading}`;
+
+const canonical = new URL(`/persons/${person.id}`, Astro.site).href;
+
+// A derived 800px portrait, as on the talk pages — never mainImage.src, which is the
+// unresized original.
+const portrait = person.data.mainImage
+    ? new URL((await getImage({ src: person.data.mainImage, width: 800, format: 'jpeg', quality: 85 })).src, Astro.site).href
+    : null;
+
+const jsonLd = [
+    personSchema({
+        name: person.data.title,
+        jobTitle: person.data.subHeading,
+        url: canonical,
+        image: portrait,
+        sameAs: [person.data.website, person.data.linkedin, person.data.xing].filter(Boolean),
+        performerIn: talks.map((talk) => ({ name: talk.data.title, url: new URL(`/talks/${talk.id}`, Astro.site).href })),
+    }),
+    breadcrumbList([
+        { name: 'Start', url: new URL('/', Astro.site).href },
+        { name: 'Personen', url: new URL('/persons', Astro.site).href },
+        { name: person.data.title, url: canonical },
+    ]),
+];
 ---
 
-<Layout title={person.data.title} description={description} mainImage={person.data.mainImage} heroImage={person.data.mainImage}>
+<Layout
+    title={person.data.title}
+    description={description}
+    mainImage={person.data.mainImage}
+    heroImage={person.data.mainImage}
+    jsonLd={jsonLd}
+>
     <section class="mx-auto mt-16 flex flex-col px-6 md:flex-row md:justify-center md:space-x-12 lg:px-24 xl:px-32">
         <Person person={person} />
 

--- a/src/pages/persons/index.astro
+++ b/src/pages/persons/index.astro
@@ -6,19 +6,27 @@
  * visual parity, even though the FlyOnUI theme is light-only so the dark variants
  * never apply.
  *
- * Kirby emitted neither a description nor JSON-LD for this template; a description
- * is added here since the page is indexed.
+ * Kirby emitted neither a description nor JSON-LD for this template; the description was
+ * added during the migration, the CollectionPage/ItemList here (#1489).
  */
 import { Icon } from 'astro-icon/components';
 import Layout from '../../layouts/Layout.astro';
 import { persons } from '../../lib/content';
 import { site } from '../../data/site';
+import { collectionPage } from '../../lib/jsonld';
 
 const all = await persons();
 const description = `Die Gäste der Talk-Reihe ${site.title} in Neuss.`;
+
+const jsonLd = collectionPage({
+    name: 'Personen',
+    url: new URL('/persons', Astro.site).href,
+    description,
+    items: all.map((p) => ({ name: p.data.title, url: new URL(`/persons/${p.id}`, Astro.site).href })),
+});
 ---
 
-<Layout title="Personen" description={description}>
+<Layout title="Personen" description={description} jsonLd={jsonLd}>
     <section class="overflow-hidden text-gray-700 dark:text-gray-400">
         <div class="container mx-auto px-5 py-24">
             <ul class="mx-auto grid max-w-(--breakpoint-sm) gap-8 sm:grid-cols-2">

--- a/src/pages/persons/index.astro
+++ b/src/pages/persons/index.astro
@@ -22,6 +22,7 @@ const jsonLd = collectionPage({
     name: 'Personen',
     url: new URL('/persons', Astro.site).href,
     description,
+    itemType: 'Person',
     items: all.map((p) => ({ name: p.data.title, url: new URL(`/persons/${p.id}`, Astro.site).href })),
 });
 ---

--- a/src/pages/talks/[slug].astro
+++ b/src/pages/talks/[slug].astro
@@ -30,7 +30,7 @@ import Person from '../../components/Person.astro';
 import { talks, persons, neighbours, isPast, excerpt, decodeEntities } from '../../lib/content';
 import { allTextBlocksHtml } from '../../lib/talkBody';
 import { formatDate, formatTime } from '../../lib/dates';
-import { eventSchema } from '../../lib/jsonld';
+import { eventSchema, breadcrumbList } from '../../lib/jsonld';
 
 export async function getStaticPaths() {
     const all = await talks();
@@ -122,19 +122,28 @@ const performerImages = new Map(
     ),
 );
 
-const jsonLd = eventSchema({
-    talk,
-    description,
-    pageUrl: canonical,
-    imageUrl: ogUrl,
-    past: !upcoming,
-    performers: attendants.map((person) => ({
-        name: person.data.title,
-        jobTitle: person.data.subHeading,
-        url: person.data.website || null,
-        image: performerImages.get(person.id) ?? null,
-    })),
-});
+// The Event MUST stay first: verify.mjs reads the first JSON-LD block on a talk page for
+// both its Event completeness checks and the past-event SoldOut assertion.
+const jsonLd = [
+    eventSchema({
+        talk,
+        description,
+        pageUrl: canonical,
+        imageUrl: ogUrl,
+        past: !upcoming,
+        performers: attendants.map((person) => ({
+            name: person.data.title,
+            jobTitle: person.data.subHeading,
+            url: person.data.website || null,
+            image: performerImages.get(person.id) ?? null,
+        })),
+    }),
+    breadcrumbList([
+        { name: 'Start', url: new URL('/', Astro.site).href },
+        { name: 'Talks', url: new URL('/talks', Astro.site).href },
+        { name: talk.data.title, url: canonical },
+    ]),
+];
 ---
 
 <Layout

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -17,6 +17,7 @@ import { talks, persons } from '../../lib/content';
 import { formatDate } from '../../lib/dates';
 import { getEntry } from 'astro:content';
 import { collectionPage } from '../../lib/jsonld';
+import { isoWithOffset } from '../../lib/dates';
 
 const page = await getEntry('pages', 'talks');
 const all = await talks();
@@ -36,7 +37,12 @@ const jsonLd = collectionPage({
     name: page?.data.title ?? 'Talks',
     url: new URL('/talks', Astro.site).href,
     description,
-    items: all.map((talk) => ({ name: talk.data.title, url: new URL(`/talks/${talk.id}`, Astro.site).href })),
+    itemType: 'Event',
+    items: all.map((talk) => ({
+        name: talk.data.title,
+        url: new URL(`/talks/${talk.id}`, Astro.site).href,
+        startDate: isoWithOffset(talk.data.date),
+    })),
 });
 ---
 

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -5,7 +5,9 @@
  * FlyOnUI timeline with the sides alternating per item — the Blade version flipped an
  * `$odd` flag each iteration, which is the index parity here.
  *
- * Kirby emitted neither a description nor JSON-LD for this template.
+ * Kirby emitted neither a description nor JSON-LD for this template; both are added now
+ * (#1489) — a page whose entire purpose is to list the talks had nothing describing the
+ * list.
  */
 import { Icon } from 'astro-icon/components';
 import Layout from '../../layouts/Layout.astro';
@@ -14,6 +16,7 @@ import PersonAvatarGroup from '../../components/PersonAvatarGroup.astro';
 import { talks, persons } from '../../lib/content';
 import { formatDate } from '../../lib/dates';
 import { getEntry } from 'astro:content';
+import { collectionPage } from '../../lib/jsonld';
 
 const page = await getEntry('pages', 'talks');
 const all = await talks();
@@ -28,9 +31,16 @@ const items = all.map((talk) => ({
 }));
 
 const description = 'Alle Ausgaben der Talk-Reihe Talk am Pegel in Neuss.';
+
+const jsonLd = collectionPage({
+    name: page?.data.title ?? 'Talks',
+    url: new URL('/talks', Astro.site).href,
+    description,
+    items: all.map((talk) => ({ name: talk.data.title, url: new URL(`/talks/${talk.id}`, Astro.site).href })),
+});
 ---
 
-<Layout title={page?.data.title ?? 'Talks'} description={description}>
+<Layout title={page?.data.title ?? 'Talks'} description={description} jsonLd={jsonLd}>
     <section class="container mx-auto my-16">
         <ul class="timeline timeline-snap-icon max-md:timeline-compact timeline-vertical timeline-centered">
             {


### PR DESCRIPTION
Fixes #1489. Closes [`seo/structured-data`](https://specification.website/spec/seo/structured-data/), [`agent-readiness/structured-data-for-agents`](https://specification.website/spec/agent-readiness/structured-data-for-agents/) (the same gap counted twice) and [`seo/breadcrumbs`](https://specification.website/spec/seo/breadcrumbs/).

### Before / after

| | before | after |
|---|---|---|
| pages with JSON-LD | 15 | **57** |
| pages without | 43 | **1** (`/404`, which is noindex) |
| node types | Event ×11, WebSite, ContactPage, WebPage ×2 | + **Person ×40**, **CollectionPage ×2**, **BreadcrumbList ×51** |

42 pages carried nothing — `/talks`, `/persons` and all 40 person pages. That was faithful to the Kirby site, which emitted none, and the templates said so. The migration is over.

### What each node says

- **`Person`** on the 40 detail pages: name, jobTitle, canonical URL, the website/LinkedIn/Xing links the collection already holds as `sameAs`, and `performerIn` listing that person's talks. The portrait goes through `getImage` at 800px — never `mainImage.src`, which is exactly where 10.8 MB of unresized originals ended up last time. Astro dedupes it to the same derived file the talk pages already reference, so **this adds no assets**.
- **`CollectionPage` + nested `ItemList`** on `/talks` and `/persons`. No `image` on those nodes: `Seo.astro` already declares the social image as meta tags, and repeating it inside the node tells a consumer nothing new.
- **`BreadcrumbList`** on all 51 detail pages — see below.

### The breadcrumb decision, stated plainly

I flagged before implementing that the spec wants **both** a visible trail and matching JSON-LD, and lists *"visible trail and JSON-LD list disagree"* as a mistake. You chose JSON-LD only, to avoid a visual change on 51 pages. Shipped as chosen.

With no trail at all there is nothing to disagree with, but this is still half of what the item asks for, so it is recorded as a deliberate deviation in `jsonld.ts` and CLAUDE.md rather than left looking like an oversight — including what a future visible trail would have to match (same items, same order, same names, same URLs; current page not a link to itself).

### The assertion that had to be inverted

The issue warned to extend the existing JSON-LD checks rather than disturb them — and section 4 asserted, in as many words, that those 42 pages had **no** JSON-LD:

```js
pass(`no JSON-LD on the ${shouldHaveNone.length} pages Kirby left bare`)
```

That parity check has served its purpose and is now the opposite: `Person` on every person page, `BreadcrumbList` on every detail page, an `ItemList` on each index page **as long as the page count** (a list that silently drops entries is worse than none), and `/404` as the only page carrying nothing. Counts derive from the page inventory rather than literals, so adding a talk or a person does not mean editing a number here.

Untouched, as instructed: the Event completeness checks and the past-event `SoldOut` assertion. Both read the *first* JSON-LD block on a talk page and bail if it is not an Event, so `Seo.astro` — which now accepts an array and emits one `<script>` per node — is passed the Event first, and the code says why.

65 → **69 assertions**.

### Verification beyond the assertions

Structurally validated every node on all 58 pages: `@context` exactly `https://schema.org`, `@type` present, `position` sequences contiguous from 1, absolute URLs throughout, `numberOfItems` matching the actual list length, `sameAs` entries all URLs. **No problems.**

Then resolved every internal URL the JSON-LD points at against the build: **58 distinct URLs, all resolve** — bar one pre-existing oddity worth a mention, not a fix. Talk 6's `locationUrl` is the site root (`https://www.talk-am-pegel.de`), from the Kirby content: a Zoom event whose location URL was set to the homepage. It resolves; it is just odd.

Worth noting what I could not do offline: Google's Rich Results Test needs a public URL, so the acceptance criterion's "validate a sample with the Rich Results Test" is worth doing once this is deployed. The structural checks above cover the shape; only Google can confirm Google's view of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)