### PR TITLE
🧭 Publish a discovery surface

### DIFF
--- a/.claude/skills/verify-live/SKILL.md
+++ b/.claude/skills/verify-live/SKILL.md
@@ -16,9 +16,9 @@ scripts/verify-live.sh                                   # production
 scripts/verify-live.sh https://<hash>.talk-am-pegel.workers.dev   # a PR preview
 ```
 
-28 checks, read-only, ~30 seconds. Exit 0 on PASS, 1 on FAIL.
+35 checks, read-only, ~30 seconds. Exit 0 on PASS, 1 on FAIL.
 
-Against a `workers.dev` preview it runs 25 and marks 3 as skipped (`-`), because the
+Against a `workers.dev` preview it runs 32 and marks 3 as skipped (`-`), because the
 apex redirect, HSTS and the managed `robots.txt` block are zone behaviours and a preview
 hostname is outside the zone. That is expected, not a regression — the script detects the
 host itself, so a preview run should still say PASS.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,14 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   every load and flashed a horizontal scrollbar. Fixed offsets now, plus `overflow-x: clip` on
   `html` as a guard. `body`'s `overflow-x: hidden` does **not** cover this; the document still
   reported the overflow with it set.
+- **Machine-readable titles are English, and carry no derived values.** The `Link` header and
+  the api-catalog label resources for whatever fetches them — they are not page content, so they
+  stay English even though the site is German. And a title must not restate a computed fact: this
+  shipped as "Alle 57 öffentlichen URLs", a second copy of a number that lives in `sitemap.xml`
+  and goes stale the moment a talk is added, silently, because the file still parses and still
+  validates. `verify.mjs` fails on a digit in any api-catalog title. `llms.txt` is the exception
+  and stays German: it is prose about German content, and that spec page wants it readable by
+  humans too.
 - **The discovery files are NOT in `scripts/expected-urls.txt`.** That fixture is the indexed
   _page_ inventory and check 1 compares it against the built HTML, so listing a non-HTML
   endpoint there reports it as missing. `/llms.txt`, `/.well-known/security.txt` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ guidance.
 pnpm dev         # Astro dev server, http://localhost:4321
 pnpm build       # -> dist/, then prunes unreferenced assets
 pnpm verify      # assert dist/ is intact (64 assertions) — also a deploy gate
-pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (28 checks)
+pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (35 checks)
 pnpm check       # astro check
 pnpm preview     # serve dist/
 pnpm deploy:cf   # build + verify + wrangler deploy
@@ -158,6 +158,19 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   every load and flashed a horizontal scrollbar. Fixed offsets now, plus `overflow-x: clip` on
   `html` as a guard. `body`'s `overflow-x: hidden` does **not** cover this; the document still
   reported the overflow with it set.
+- **The discovery files are NOT in `scripts/expected-urls.txt`.** That fixture is the indexed
+  _page_ inventory and check 1 compares it against the built HTML, so listing a non-HTML
+  endpoint there reports it as missing. `/llms.txt`, `/.well-known/security.txt` and
+  `/.well-known/api-catalog` live in check 1's second list, beside `sitemap.xml` and
+  `robots.txt` — which leaves the 57-URL invariant exactly where it was.
+- **`security.txt`'s `Expires` is a build gate, not a calendar note.** RFC 9116 requires the
+  field and the file is invalid once it lapses, so `verify.mjs` fails when it is under 30 days
+  out and says so. If a build starts failing with "security.txt expires in 12 days", the fix is
+  to set a new date in `public/.well-known/security.txt`, not to weaken the check.
+- **Two `Content-Type` overrides in `public/_headers` are load-bearing.** `/.well-known/api-catalog`
+  has no extension, so it would be served as `application/octet-stream` where RFC 9727 requires
+  `application/linkset+json`; and `/llms.txt` is typed `text/markdown` to match what the `Link`
+  header advertises. `verify-live.sh` asserts both, because only the edge can show them.
 - **JSON-LD goes out through `set:html`, so `<` must stay escaped.** `JSON.stringify` does not
   escape it, and a value containing `</script>` would close the block and turn the rest into
   markup. `Seo.astro` replaces `<` with `\u003c` — byte-identical data to a consumer — and

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -6,21 +6,21 @@
                 {
                     "href": "https://www.talk-am-pegel.de/llms.txt",
                     "type": "text/markdown",
-                    "title": "Kuratierter Index für Agenten"
+                    "title": "Curated index for agents"
                 }
             ],
             "sitemap": [
                 {
                     "href": "https://www.talk-am-pegel.de/sitemap.xml",
                     "type": "application/xml",
-                    "title": "Alle 57 öffentlichen URLs"
+                    "title": "XML sitemap of all public pages"
                 }
             ],
             "security": [
                 {
                     "href": "https://www.talk-am-pegel.de/.well-known/security.txt",
                     "type": "text/plain",
-                    "title": "Kontakt für Sicherheitsmeldungen"
+                    "title": "Security contact"
                 }
             ]
         }

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,28 @@
+{
+    "linkset": [
+        {
+            "anchor": "https://www.talk-am-pegel.de/",
+            "describedby": [
+                {
+                    "href": "https://www.talk-am-pegel.de/llms.txt",
+                    "type": "text/markdown",
+                    "title": "Kuratierter Index für Agenten"
+                }
+            ],
+            "sitemap": [
+                {
+                    "href": "https://www.talk-am-pegel.de/sitemap.xml",
+                    "type": "application/xml",
+                    "title": "Alle 57 öffentlichen URLs"
+                }
+            ],
+            "security": [
+                {
+                    "href": "https://www.talk-am-pegel.de/.well-known/security.txt",
+                    "type": "text/plain",
+                    "title": "Kontakt für Sicherheitsmeldungen"
+                }
+            ]
+        }
+    ]
+}

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,7 @@
+# RFC 9116. Expires is REQUIRED and the file is invalid once it lapses, so
+# scripts/verify.mjs fails the build when it is less than 30 days out — the reminder
+# lives in the deploy gate rather than in somebody's calendar.
+Contact: mailto:info@talk-am-pegel.de
+Expires: 2027-09-07T00:00:00Z
+Preferred-Languages: de, en
+Canonical: https://www.talk-am-pegel.de/.well-known/security.txt

--- a/public/_headers
+++ b/public/_headers
@@ -29,13 +29,18 @@
 
 # Discovery, at the edge rather than in the markup, so a non-HTML response carries it
 # too — an agent that fetches /sitemap.xml first still learns where everything else is.
+#
+# Titles here and in the api-catalog are ENGLISH even though the site is German: they
+# label the resource for whatever fetches it, they are not page content. And they carry
+# no derived values — a title that restates a count ("all 57 URLs") is a second copy of a
+# fact that lives in sitemap.xml, and the copy goes stale silently.
 # Root-relative because it is portable across protocol and host; `type` and `title` so a
 # consumer does not need a second fetch to know what it is looking at.
 #
 # `describedby` for llms.txt is v2 of that convention's one hard requirement: without it
 # an agent is back to guessing the path.
 /*
-  Link: </llms.txt>; rel="describedby"; type="text/markdown"; title="Kuratierter Index für Agenten", </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </sitemap.xml>; rel="sitemap"; type="application/xml", </.well-known/security.txt>; rel="security"; type="text/plain"
+  Link: </llms.txt>; rel="describedby"; type="text/markdown"; title="Curated index for agents", </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </sitemap.xml>; rel="sitemap"; type="application/xml", </.well-known/security.txt>; rel="security"; type="text/plain"
   X-Content-Type-Options: nosniff
   # Nothing here is meant to be framed, and the site has no embed use case. Replace
   # with CSP frame-ancestors 'none' once a policy exists (issue #1487) — until then

--- a/public/_headers
+++ b/public/_headers
@@ -40,7 +40,7 @@
 # `describedby` for llms.txt is v2 of that convention's one hard requirement: without it
 # an agent is back to guessing the path.
 /*
-  Link: </llms.txt>; rel="describedby"; type="text/markdown"; title="Curated index for agents", </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </sitemap.xml>; rel="sitemap"; type="application/xml", </.well-known/security.txt>; rel="security"; type="text/plain"
+  Link: </llms.txt>; rel="describedby"; type="text/markdown"; title="Curated index for agents", </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; title="API catalogue", </sitemap.xml>; rel="sitemap"; type="application/xml"; title="XML sitemap of all public pages", </.well-known/security.txt>; rel="security"; type="text/plain"; title="Security contact"
   X-Content-Type-Options: nosniff
   # Nothing here is meant to be framed, and the site has no embed use case. Replace
   # with CSP frame-ancestors 'none' once a policy exists (issue #1487) — until then

--- a/public/_headers
+++ b/public/_headers
@@ -27,7 +27,15 @@
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable
 
+# Discovery, at the edge rather than in the markup, so a non-HTML response carries it
+# too — an agent that fetches /sitemap.xml first still learns where everything else is.
+# Root-relative because it is portable across protocol and host; `type` and `title` so a
+# consumer does not need a second fetch to know what it is looking at.
+#
+# `describedby` for llms.txt is v2 of that convention's one hard requirement: without it
+# an agent is back to guessing the path.
 /*
+  Link: </llms.txt>; rel="describedby"; type="text/markdown"; title="Kuratierter Index für Agenten", </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json", </sitemap.xml>; rel="sitemap"; type="application/xml", </.well-known/security.txt>; rel="security"; type="text/plain"
   X-Content-Type-Options: nosniff
   # Nothing here is meant to be framed, and the site has no embed use case. Replace
   # with CSP frame-ancestors 'none' once a policy exists (issue #1487) — until then
@@ -51,3 +59,14 @@
   # so nothing varies on these. It matters the moment a campaign link is shared — a
   # prefetch of /talks?utm_source=x can then satisfy a visit to /talks.
   No-Vary-Search: params=("utm_source" "utm_medium" "utm_campaign" "utm_content" "utm_term" "gclid" "fbclid" "msclkid" "ref"), key-order
+
+# Two Content-Type overrides. Cloudflare types by extension, which gets .txt right as
+# text/plain — allowed for llms.txt, but we advertise type="text/markdown" in the Link
+# header above and the two should not disagree. The api-catalog has no extension at all,
+# and RFC 9727 requires application/linkset+json; an extensionless file would otherwise
+# be served as application/octet-stream, which is the mistake the spec names.
+/llms.txt
+  Content-Type: text/markdown; charset=utf-8
+
+/.well-known/api-catalog
+  Content-Type: application/linkset+json; charset=utf-8

--- a/scripts/verify-live.sh
+++ b/scripts/verify-live.sh
@@ -210,7 +210,38 @@ esac
 
 # ---------------------------------------------------------------------------
 echo
-echo "8. robots.txt and sitemap.xml"
+echo "8. Discovery surface — the files, their types, and the Link header"
+# dist/_headers and dist/.well-known/ are instructions and static files; only a live
+# response shows whether Cloudflare served them, and with which Content-Type. An
+# extensionless file like api-catalog defaults to application/octet-stream on most hosts,
+# which is the mistake RFC 9727's spec page calls out.
+disc() { # path, expected status, expected content-type fragment
+    local h code ctype
+    h=$(headers "$BASE$1")
+    code=$(printf '%s' "$h" | head -1 | awk '{print $2}')
+    ctype=$(hdr content-type "$h")
+    if [ "$code" != "200" ]; then
+        no "$1 -> $code"
+    elif [ -n "$2" ] && ! printf '%s' "$ctype" | grep -qi "$2"; then
+        no "$1 served as '$ctype', expected $2"
+    else
+        ok "$1 -> 200 $ctype"
+    fi
+}
+disc /llms.txt 'text/markdown'
+disc /.well-known/security.txt 'text/plain'
+disc /.well-known/api-catalog 'application/linkset+json'
+
+# The Link header is what makes the above discoverable without guessing a path — llms.txt
+# v2 exists because the guess never worked.
+l=$(hdr link "$(headers "$BASE/")")
+for rel in describedby api-catalog sitemap security; do
+    printf '%s' "$l" | grep -q "rel=\"$rel\"" && ok "Link header advertises rel=\"$rel\"" || no "Link header has no rel=\"$rel\": ${l:-(no Link header)}"
+done
+
+# ---------------------------------------------------------------------------
+echo
+echo "9. robots.txt and sitemap.xml"
 r=$("${CURL[@]}" "$BASE/robots.txt")
 printf '%s' "$r" | grep -qi 'sitemap:.*sitemap\.xml' && ok "robots.txt points at /sitemap.xml" || no "robots.txt has no sitemap line"
 # Cloudflare PREPENDS a managed AI-bot block to the origin file. It has silently stopped

--- a/scripts/verify-live.sh
+++ b/scripts/verify-live.sh
@@ -215,7 +215,7 @@ echo "8. Discovery surface — the files, their types, and the Link header"
 # response shows whether Cloudflare served them, and with which Content-Type. An
 # extensionless file like api-catalog defaults to application/octet-stream on most hosts,
 # which is the mistake RFC 9727's spec page calls out.
-disc() { # path, expected status, expected content-type fragment
+disc() { # $1 = path, $2 = expected Content-Type fragment (status is always 200)
     local h code ctype
     h=$(headers "$BASE$1")
     code=$(printf '%s' "$h" | head -1 | awk '{print $2}')

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -28,6 +28,8 @@
  *      does not advertise unresized originals
  *  13. Head and manifest: description + og:description on every page, a colour
  *      scheme, and an installable manifest whose icons exist
+ *  14. Discovery surface: llms.txt, security.txt and the api-catalog are
+ *      well formed, advertised, and not about to expire
  */
 
 import fs from 'node:fs';
@@ -174,7 +176,20 @@ console.log('\n1. URL inventory');
     if (!missing.length && !extra.length) pass(`all ${expected.length} Kirby URLs built, none extra`);
     if (fs.existsSync(path.join(DIST, '404.html'))) pass('404.html present');
     else fail('404.html missing');
-    for (const f of ['sitemap.xml', 'robots.txt', 'favicon.ico', 'favicon.svg', 'site.webmanifest', 'ads.txt'])
+    // Not expected-urls.txt: that fixture is the INDEXED PAGE inventory, compared against
+    // the built HTML above, so listing a non-HTML endpoint there reports it as missing.
+    // Discovery files belong in this list instead, which leaves the 57-URL invariant alone.
+    for (const f of [
+        'sitemap.xml',
+        'robots.txt',
+        'favicon.ico',
+        'favicon.svg',
+        'site.webmanifest',
+        'ads.txt',
+        'llms.txt',
+        '.well-known/security.txt',
+        '.well-known/api-catalog',
+    ])
         fs.existsSync(path.join(DIST, f)) ? pass(`${f} present`) : fail(`${f} missing`);
 }
 
@@ -783,6 +798,78 @@ console.log('\n13. Head and manifest');
         else if (!startResolves) fail(`manifest start_url "${startUrl}" does not resolve to a built page`);
         else pass(`manifest start_url "${startUrl}" is root-relative and resolves`);
     }
+}
+
+// -------------------------------------------------------- 14. discovery surface
+console.log('\n14. Discovery surface');
+{
+    const resolves = (url) => {
+        const p = url.replace(/^https:\/\/www\.talk-am-pegel\.de/, '').split(/[?#]/)[0];
+        const targets = p === '/' ? ['index.html'] : [p.replace(/^\//, ''), `${p.replace(/^\//, '')}.html`];
+        return targets.some((t) => fs.existsSync(path.join(DIST, t)));
+    };
+
+    // --- llms.txt: the format llmstxt.org describes, and curated rather than exhaustive
+    const llms = read(path.join(DIST, 'llms.txt'));
+    llms.startsWith(`# `) ? pass('llms.txt opens with an H1') : fail('llms.txt does not start with "# "');
+    /^>\s+\S/m.test(llms) ? pass('llms.txt carries a blockquote summary') : fail('llms.txt has no "> summary" line');
+    const llmsLinks = [...llms.matchAll(/\]\((https:\/\/[^)]+)\)/g)].map((m) => m[1]);
+    const llmsBroken = llmsLinks.filter((u) => !resolves(u));
+    llmsBroken.length === 0
+        ? pass(`all ${llmsLinks.length} llms.txt links resolve`)
+        : fail(`llms.txt links that do not resolve: ${llmsBroken.slice(0, 3).join(', ')}`);
+    // A stale llms.txt teaches models wrong things, and the failure mode is silent: it
+    // still parses, it just describes a site that no longer exists. Every talk must be in
+    // it, so adding one without touching this file fails here rather than in a model.
+    const talkPageCount = pages.filter((f) => toUrl(f).startsWith('/talks/')).length;
+    const listedTalks = llmsLinks.filter((u) => u.includes('/talks/')).length;
+    listedTalks === talkPageCount
+        ? pass(`llms.txt lists all ${talkPageCount} talks`)
+        : fail(`llms.txt lists ${listedTalks} of ${talkPageCount} talks — has a talk been added without updating it?`);
+
+    // --- security.txt: RFC 9116 requires Contact and Expires, and is invalid once
+    // Expires lapses. Failing 30 days out puts the reminder in the deploy gate.
+    const sec = read(path.join(DIST, '.well-known', 'security.txt'));
+    /^Contact:\s*\S/m.test(sec) ? pass('security.txt has a Contact') : fail('security.txt has no Contact field');
+    const expires = sec.match(/^Expires:\s*(\S+)/m)?.[1];
+    const days = expires ? Math.floor((Date.parse(expires) - Date.now()) / 86400000) : null;
+    if (!expires) fail('security.txt has no Expires field — the file is invalid per RFC 9116 without it');
+    else if (Number.isNaN(Date.parse(expires))) fail(`security.txt Expires is not a parseable timestamp: ${expires}`);
+    else if (days < 0) fail(`security.txt EXPIRED ${-days} days ago (${expires}) — the file is invalid; set a new Expires`);
+    else if (days < 30) fail(`security.txt expires in ${days} days (${expires}) — set a new Expires now`);
+    else pass(`security.txt expires in ${days} days`);
+
+    // --- api-catalog: RFC 9727 wants a Linkset, and every href in it has to exist
+    let catalog = null;
+    try {
+        catalog = JSON.parse(read(path.join(DIST, '.well-known', 'api-catalog')));
+    } catch {
+        fail('.well-known/api-catalog does not parse as JSON');
+    }
+    if (catalog) {
+        const entries = Array.isArray(catalog.linkset) ? catalog.linkset : [];
+        const hrefs = entries.flatMap((e) =>
+            Object.entries(e)
+                .filter(([k]) => k !== 'anchor')
+                .flatMap(([, links]) => (Array.isArray(links) ? links.map((l) => l.href) : [])),
+        );
+        const broken = hrefs.filter((u) => typeof u !== 'string' || !resolves(u));
+        entries.length > 0 && entries.every((e) => typeof e.anchor === 'string')
+            ? pass(`api-catalog is a Linkset with ${entries.length} anchored entr(y/ies)`)
+            : fail('api-catalog has no linkset array, or an entry without an anchor');
+        broken.length === 0
+            ? pass(`all ${hrefs.length} api-catalog links resolve`)
+            : fail(`api-catalog links that do not resolve: ${broken.slice(0, 3).join(', ')}`);
+    }
+
+    // --- and the header that makes any of it discoverable. dist/_headers is a Cloudflare
+    // instruction file, so this only proves we asked; verify-live.sh proves it applied.
+    const headers = read(path.join(DIST, '_headers'));
+    const rels = ['describedby', 'api-catalog', 'sitemap', 'security'];
+    const missingRels = rels.filter((r) => !new RegExp(`rel="${r}"`).test(headers));
+    missingRels.length === 0
+        ? pass(`_headers advertises ${rels.join(', ')}`)
+        : fail(`_headers Link header missing rel(s): ${missingRels.join(', ')}`);
 }
 
 console.log(`\n${failures === 0 ? 'PASS' : 'FAIL'} — ${checks} checks passed, ${failures} failure(s)\n`);

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -860,6 +860,21 @@ console.log('\n14. Discovery surface');
         broken.length === 0
             ? pass(`all ${hrefs.length} api-catalog links resolve`)
             : fail(`api-catalog links that do not resolve: ${broken.slice(0, 3).join(', ')}`);
+
+        // No derived values in the titles. This shipped as "Alle 57 öffentlichen URLs",
+        // which is a second copy of a number that lives in sitemap.xml — and the copy
+        // goes stale the moment a talk is added, silently, because the file still parses
+        // and still validates. A reviewer caught it by eye; this is cheaper than a
+        // reviewer. Relax it if a versioned API ever needs "OpenAPI 3.1" in a title.
+        const titles = entries.flatMap((e) =>
+            Object.entries(e)
+                .filter(([k]) => k !== 'anchor')
+                .flatMap(([, links]) => (Array.isArray(links) ? links.map((l) => l.title).filter(Boolean) : [])),
+        );
+        const numeric = titles.filter((t) => /\d/.test(t));
+        numeric.length === 0
+            ? pass(`all ${titles.length} api-catalog titles are free of derived values`)
+            : fail(`api-catalog title(s) contain a number that will drift: ${numeric.join(' | ')}`);
     }
 
     // --- and the header that makes any of it discoverable. dist/_headers is a Cloudflare

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -42,7 +42,7 @@ ${talkLines}
 ## Seiten
 
 - [Alle Talks](${base}/talks): Übersicht aller Ausgaben, chronologisch.
-- [Personen](${base}/persons): die Gäste der Reihe, mit je einer eigenen Seite.
+- [Personen](${base}/persons): Gäste der Reihe, mit je einer eigenen Seite.
 - [${pageTitle('kontakt')}](${base}/kontakt): Anschrift, Telefon und E-Mail der Veranstalter.
 
 ## Optional

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,55 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { talks } from '../lib/content';
+import { site } from '../data/site';
+import { formatDate } from '../lib/dates';
+
+/**
+ * /llms.txt — a curated index for agents, in the format llmstxt.org describes: an H1
+ * with the site name, a blockquote summary, then `##` sections of markdown links.
+ *
+ * CURATED, not exhaustive. The spec's first listed mistake is "treating it like a
+ * sitemap and listing every URL" — /sitemap.xml already enumerates all 57. So the 11
+ * talks are listed individually, because they are the substance of the site, and the 40
+ * guest pages are represented by /persons rather than 40 lines of names.
+ *
+ * v2 of the convention requires the file be ADVERTISED rather than guessed at:
+ * `Link: </llms.txt>; rel="describedby"; type="text/markdown"` comes from public/_headers,
+ * which also overrides the Content-Type — Cloudflare would otherwise serve a .txt file as
+ * text/plain, which the convention allows but which contradicts the `type` we advertise.
+ */
+export const GET: APIRoute = async ({ site: astroSite }) => {
+    const base = astroSite!.origin;
+    const all = await talks();
+    const pages = await getCollection('pages');
+    const pageTitle = (id: string) => pages.find((p) => p.id === id)?.data.title ?? id;
+
+    const talkLines = all
+        .map((talk) => `- [${talk.data.title}](${base}/talks/${talk.id}): ${talk.data.textline}, ${formatDate(talk.data.date)}.`)
+        .join('\n');
+
+    const body = `# ${site.title}
+
+> ${site.title} ist eine Gesprächsreihe in Neuss: Abende mit Gästen aus Politik, Wirtschaft und Gesellschaft, veranstaltet von ${site.address1}.
+
+Diese Datei ist ein kuratierter Index für Sprachmodelle und Agenten. Die vollständige
+URL-Liste steht in [sitemap.xml](${base}/sitemap.xml).
+
+## Talks
+
+${talkLines}
+
+## Seiten
+
+- [Alle Talks](${base}/talks): Übersicht aller Ausgaben, chronologisch.
+- [Personen](${base}/persons): die Gäste der Reihe, mit je einer eigenen Seite.
+- [${pageTitle('kontakt')}](${base}/kontakt): Anschrift, Telefon und E-Mail der Veranstalter.
+
+## Optional
+
+- [${pageTitle('impressum')}](${base}/impressum)
+- [${pageTitle('datenschutz')}](${base}/datenschutz)
+`;
+
+    return new Response(body, { headers: { 'Content-Type': 'text/markdown; charset=utf-8' } });
+};


### PR DESCRIPTION
Fixes #1488. Closes [`agent-readiness/llms-txt`](https://specification.website/spec/agent-readiness/llms-txt/), [`well-known/well-known-overview`](https://specification.website/spec/well-known/well-known-overview/), [`well-known/api-catalog`](https://specification.website/spec/well-known/api-catalog/), [`security/security-txt`](https://specification.website/spec/security/security-txt/) and [`agent-readiness/link-headers`](https://specification.website/spec/agent-readiness/link-headers/).

The site had no discovery surface at all: no `llms.txt`, no `.well-known/` directory, no `Link` header on any response. `/sitemap.xml` was the only machine-readable endpoint.

### What ships

**`/llms.txt`** — generated from the content collections, in the format llmstxt.org describes: H1, blockquote summary, `##` sections of links. **Curated, not exhaustive**: the 11 talks are listed individually because they are the substance of the site; the 40 guest pages are represented by `/persons` rather than 40 lines of names. *"Treating it like a sitemap and listing every URL"* is the first mistake that spec page names, and `sitemap.xml` already does exhaustive.

**`/.well-known/security.txt`** — RFC 9116: `Contact`, `Expires`, `Preferred-Languages`, `Canonical`.

**`/.well-known/api-catalog`** — an RFC 9264 Linkset anchored at the site root, pointing at `llms.txt` (`describedby`), the sitemap (`sitemap`) and `security.txt` (`security`), modelled on the reference implementation's own catalogue.

**One `Link` header on `/*`** advertising all of it. At the edge rather than in the markup, as that spec page recommends — *"so non-HTML responses get them too"* — which means an agent entering via `sitemap.xml` still learns where everything else is. `rel="describedby"` is not garnish: it is llms.txt **v2's one hard requirement**, added precisely because guessing the path never worked.

### Two Content-Type overrides that carry weight

- `/.well-known/api-catalog` has **no extension**, so Cloudflare would serve it as `application/octet-stream` where RFC 9727 requires `application/linkset+json` — the mistake that spec page explicitly calls out.
- `/llms.txt` is typed `text/markdown` so the file does not contradict the `type` the `Link` header advertises.

Only a live response can show either, so `verify-live.sh` asserts both.

### One correction to the issue

The issue says each new URL must be added to `scripts/expected-urls.txt` "or `pnpm verify` fails by design". **The opposite is true**: check 1 compares that fixture against the built **HTML** inventory, so a non-HTML endpoint listed there is reported as `missing pages: /llms.txt`. They belong in check 1's second list, beside `sitemap.xml` and `robots.txt`.

Consequences worth stating: the **57-URL invariant is untouched**, and the `PreToolUse` hook on `expected-urls.txt` never fires — there was nothing to prompt about.

### The `Expires` reminder is a build gate

The issue asked for the annual refresh reminder to live "somewhere durable". A calendar entry is not durable; the deploy gate is:

```
✓ security.txt expires in 364 days
```

Under 30 days it fails with `security.txt expires in 12 days (…) — set a new Expires now`, and once lapsed it fails saying the file is invalid per RFC 9116. The fix is a new date in `public/.well-known/security.txt`, not a weaker check.

### Verification

`verify.mjs` 70 → **82**:

```
14. Discovery surface
  ✓ llms.txt opens with an H1
  ✓ llms.txt carries a blockquote summary
  ✓ all 17 llms.txt links resolve
  ✓ llms.txt lists all 11 talks
  ✓ security.txt has a Contact
  ✓ security.txt expires in 364 days
  ✓ api-catalog is a Linkset with 1 anchored entr(y/ies)
  ✓ all 3 api-catalog links resolve
  ✓ _headers advertises describedby, api-catalog, sitemap, security
```

The talk-count check is the one that earns its keep long-term: *"a stale llms.txt is worse than none — it teaches models wrong things"*, and it fails silently, since the file still parses. Adding a talk without updating the index now fails the build instead.

`verify-live.sh` gains 7 checks (28 → **35**) — each file's status **and** Content-Type, plus each `rel` on the live header. All 7 confirmed to fail against current production before this deploys:

```
✗ /llms.txt -> 404
✗ /.well-known/api-catalog -> 404
✗ Link header has no rel="describedby": (no Link header)
```

### Deliberately not done

- **No `<link rel="describedby">` in the head.** The spec allows "a `<link>` in the head, an HTTP `Link` header, or both" and recommends the edge as the right layer; the header covers non-HTML responses, which the head cannot.
- **No footer link for humans.** That spec page suggests one, but this site's audience is event attendees, and a "llms.txt" item beside Kontakt/Impressum/Datenschutz would be noise for every one of them. Happy to add it if you disagree.
- **No `/llms-full.txt`.** Separate spec item, not in this issue; the site is 57 pages and the per-page Markdown question is #1492's to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)