### PR TITLE
📡 Publish an RSS feed of the talks

### DIFF
--- a/.claude/skills/verify-live/SKILL.md
+++ b/.claude/skills/verify-live/SKILL.md
@@ -16,9 +16,9 @@ scripts/verify-live.sh                                   # production
 scripts/verify-live.sh https://<hash>.talk-am-pegel.workers.dev   # a PR preview
 ```
 
-35 checks, read-only, ~30 seconds. Exit 0 on PASS, 1 on FAIL.
+37 checks, read-only, ~30 seconds. Exit 0 on PASS, 1 on FAIL.
 
-Against a `workers.dev` preview it runs 32 and marks 3 as skipped (`-`), because the
+Against a `workers.dev` preview it runs 34 and marks 3 as skipped (`-`), because the
 apex redirect, HSTS and the managed `robots.txt` block are zone behaviours and a preview
 hostname is outside the zone. That is expected, not a regression — the script detects the
 host itself, so a preview run should still say PASS.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ guidance.
 pnpm dev         # Astro dev server, http://localhost:4321
 pnpm build       # -> dist/, then prunes unreferenced assets
 pnpm verify      # assert dist/ is intact (64 assertions) — also a deploy gate
-pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (35 checks)
+pnpm verify:live # sweep the LIVE site: URLs, redirects, headers, robots.txt (37 checks)
 pnpm check       # astro check
 pnpm preview     # serve dist/
 pnpm deploy:cf   # build + verify + wrangler deploy
@@ -158,6 +158,17 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   every load and flashed a horizontal scrollbar. Fixed offsets now, plus `overflow-x: clip` on
   `html` as a guard. `body`'s `overflow-x: hidden` does **not** cover this; the document still
   reported the overflow with it set.
+- **`/rss.xml` exists because three spec items pointed at it, one of them circularly.**
+  `machine-readable-formats` asks for a feed; `feed-discovery` and `feed-hygiene` had been graded
+  N/A _because no feed existed_, which decided the question by assuming it. A series publishing
+  two or three times a year is what RSS is actually for, so the feed is for readers first and
+  agents second. Its shape follows the feed-hygiene page and every part earns its place:
+  `atom:link rel="self"` (both validators warn without it), `<guid isPermaLink="true">` equal to
+  the link and **never** changing (readers key read-state off it), RFC 822 dates, absolute URLs
+  inside items, and `<content:encoded>` carrying the whole text so the feed is not a teaser.
+  `lastBuildDate` is the newest talk's date, not the build time — a typo fix in the footer is not
+  a content change. `_headers` types it `application/rss+xml`, because readers branch on the MIME
+  type and Cloudflare would otherwise serve `.xml` as `application/xml`.
 - **Machine-readable titles are English, and carry no derived values.** The `Link` header and
   the api-catalog label resources for whatever fetches them — they are not page content, so they
   stay English even though the site is German. And a title must not restate a computed fact: this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,11 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   `lastBuildDate` is the newest talk's date, not the build time — a typo fix in the footer is not
   a content change. `_headers` types it `application/rss+xml`, because readers branch on the MIME
   type and Cloudflare would otherwise serve `.xml` as `application/xml`.
+- **`]]>` in feed content is SPLIT, never escaped.** Entities are not parsed inside a CDATA
+  section, so `]]&gt;` reaches the reader as those five literal characters; closing the section
+  after the `]]` and reopening for the `>` leaves the parsed text byte-identical. Verified
+  against a real XML parser both ways. `verify.mjs` fails if a CDATA section ever contains
+  `]]&gt;`, or if the sections stop balancing.
 - **Machine-readable titles are English, and carry no derived values.** The `Link` header and
   the api-catalog label resources for whatever fetches them — they are not page content, so they
   stay English even though the site is German. And a title must not restate a computed fact: this

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -9,6 +9,13 @@
                     "title": "Curated index for agents"
                 }
             ],
+            "alternate": [
+                {
+                    "href": "https://www.talk-am-pegel.de/rss.xml",
+                    "type": "application/rss+xml",
+                    "title": "Talks feed"
+                }
+            ],
             "sitemap": [
                 {
                     "href": "https://www.talk-am-pegel.de/sitemap.xml",

--- a/public/_headers
+++ b/public/_headers
@@ -40,7 +40,7 @@
 # `describedby` for llms.txt is v2 of that convention's one hard requirement: without it
 # an agent is back to guessing the path.
 /*
-  Link: </llms.txt>; rel="describedby"; type="text/markdown"; title="Curated index for agents", </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; title="API catalogue", </sitemap.xml>; rel="sitemap"; type="application/xml"; title="XML sitemap of all public pages", </.well-known/security.txt>; rel="security"; type="text/plain"; title="Security contact"
+  Link: </llms.txt>; rel="describedby"; type="text/markdown"; title="Curated index for agents", </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; title="API catalogue", </sitemap.xml>; rel="sitemap"; type="application/xml"; title="XML sitemap of all public pages", </.well-known/security.txt>; rel="security"; type="text/plain"; title="Security contact", </rss.xml>; rel="alternate"; type="application/rss+xml"; title="Talks feed"
   X-Content-Type-Options: nosniff
   # Nothing here is meant to be framed, and the site has no embed use case. Replace
   # with CSP frame-ancestors 'none' once a policy exists (issue #1487) — until then
@@ -75,3 +75,8 @@
 
 /.well-known/api-catalog
   Content-Type: application/linkset+json; charset=utf-8
+
+# Cloudflare types .xml as application/xml, which is right for the sitemap and wrong for a
+# feed: readers branch on the MIME type, and RSS 2.0 is application/rss+xml.
+/rss.xml
+  Content-Type: application/rss+xml; charset=utf-8

--- a/scripts/verify-live.sh
+++ b/scripts/verify-live.sh
@@ -238,11 +238,12 @@ disc() { # $1 = path, $2 = expected Content-Type fragment (status is always 200)
 disc /llms.txt 'text/markdown'
 disc /.well-known/security.txt 'text/plain'
 disc /.well-known/api-catalog 'application/linkset+json'
+disc /rss.xml 'application/rss+xml'
 
 # The Link header is what makes the above discoverable without guessing a path — llms.txt
 # v2 exists because the guess never worked.
 l=$(hdr link "$(headers "$BASE/")")
-for rel in describedby api-catalog sitemap security; do
+for rel in describedby api-catalog sitemap security alternate; do
     printf '%s' "$l" | grep -q "rel=\"$rel\"" && ok "Link header advertises rel=\"$rel\"" || no "Link header has no rel=\"$rel\": ${l:-(no Link header)}"
 done
 

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -28,8 +28,8 @@
  *      does not advertise unresized originals
  *  13. Head and manifest: description + og:description on every page, a colour
  *      scheme, and an installable manifest whose icons exist
- *  14. Discovery surface: llms.txt, security.txt and the api-catalog are
- *      well formed, advertised, and not about to expire
+ *  14. Discovery surface: llms.txt, the feed, security.txt and the api-catalog
+ *      are well formed, advertised, and not about to expire
  */
 
 import fs from 'node:fs';
@@ -187,6 +187,7 @@ console.log('\n1. URL inventory');
         'site.webmanifest',
         'ads.txt',
         'llms.txt',
+        'rss.xml',
         '.well-known/security.txt',
         '.well-known/api-catalog',
     ])
@@ -877,6 +878,51 @@ console.log('\n14. Discovery surface');
             : fail(`api-catalog title(s) contain a number that will drift: ${numeric.join(' | ')}`);
     }
 
+    // --- the feed. Its shape comes from the feed-hygiene spec page, and every one of
+    // these has a named failure mode there: a missing self-link is flagged by both
+    // validators, a GUID that changes breaks every reader's read state, a relative URL
+    // inside an item resolves against the reader rather than the site, and truncating to
+    // a teaser is the first listed mistake.
+    const feed = read(path.join(DIST, 'rss.xml'));
+    const feedItems = [...feed.matchAll(/<item>([\s\S]*?)<\/item>/g)].map((m) => m[1]);
+    const talkCount = pages.filter((f) => toUrl(f).startsWith('/talks/')).length;
+
+    feedItems.length === talkCount
+        ? pass(`feed carries all ${talkCount} talks`)
+        : fail(`feed has ${feedItems.length} items for ${talkCount} talks`);
+    // Attribute order is not significant in XML, so match the tag and then test its
+    // attributes — the first version of this check demanded rel before href and failed on
+    // a feed that xmllint and a real XML parser both accepted.
+    const selfLink = [...feed.matchAll(/<atom:link\b[^>]*>/g)].find(
+        (m) => /rel="self"/.test(m[0]) && /href="https:\/\/[^"]+\/rss\.xml"/.test(m[0]),
+    );
+    selfLink ? pass('feed has an atom:link rel="self"') : fail('feed has no atom:link rel="self" pointing at its own URL');
+
+    const feedProblems = [];
+    let previousDate = Infinity;
+    for (const item of feedItems) {
+        const link = item.match(/<link>([^<]+)<\/link>/)?.[1] ?? '';
+        const guid = item.match(/<guid[^>]*>([^<]+)<\/guid>/)?.[1] ?? '';
+        const pub = item.match(/<pubDate>([^<]+)<\/pubDate>/)?.[1] ?? '';
+        const desc = item.match(/<description>([\s\S]*?)<\/description>/)?.[1] ?? '';
+        const full = item.match(/<content:encoded>([\s\S]*?)<\/content:encoded>/)?.[1] ?? '';
+        if (!link.startsWith('https://')) feedProblems.push(`relative or missing link: ${link}`);
+        if (guid !== link) feedProblems.push(`guid does not match link: ${guid}`);
+        if (Number.isNaN(Date.parse(pub))) feedProblems.push(`unparseable pubDate: ${pub}`);
+        else if (Date.parse(pub) > previousDate) feedProblems.push('items are not newest-first');
+        else previousDate = Date.parse(pub);
+        if (full.length < desc.length) feedProblems.push(`content:encoded shorter than description for ${link}`);
+    }
+    feedProblems.length === 0
+        ? pass(`all ${feedItems.length} feed items are absolute, GUID-stable, dated and un-truncated`)
+        : fail(`feed problems: ${feedProblems.slice(0, 3).join(' | ')}`);
+
+    // Discovery: a feed nobody can find is a file nobody fetches.
+    const undiscoverable = pages.filter((f) => !/<link rel="alternate"[^>]+application\/rss\+xml[^>]+title="[^"]+"/.test(read(f)));
+    undiscoverable.length === 0
+        ? pass(`all ${pages.length} pages link the feed with a title`)
+        : fail(`${undiscoverable.length} page(s) without a titled rel="alternate" feed link`);
+
     // --- the canonicalisation rules. Like _headers, dist/_redirects is an instruction
     // file rather than output, so this only proves we asked for 308s; verify-live.sh
     // section 3 proves Cloudflare applied them, which is the half that can actually
@@ -897,7 +943,7 @@ console.log('\n14. Discovery surface');
     // --- and the header that makes any of it discoverable. dist/_headers is a Cloudflare
     // instruction file, so this only proves we asked; verify-live.sh proves it applied.
     const headers = read(path.join(DIST, '_headers'));
-    const rels = ['describedby', 'api-catalog', 'sitemap', 'security'];
+    const rels = ['describedby', 'api-catalog', 'sitemap', 'security', 'alternate'];
     const missingRels = rels.filter((r) => !new RegExp(`rel="${r}"`).test(headers));
     missingRels.length === 0
         ? pass(`_headers advertises ${rels.join(', ')}`)

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -890,6 +890,20 @@ console.log('\n14. Discovery surface');
     feedItems.length === talkCount
         ? pass(`feed carries all ${talkCount} talks`)
         : fail(`feed has ${feedItems.length} items for ${talkCount} talks`);
+
+    // CDATA sections must balance, and must never carry an escaped `]]&gt;`: entities are
+    // not parsed inside CDATA, so that sequence reaches the reader as those literal
+    // characters. Content containing `]]>` has to SPLIT the section instead.
+    const opens = (feed.match(/<!\[CDATA\[/g) ?? []).length;
+    const closes = (feed.match(/]]>/g) ?? []).length;
+    const escapedInside = /<!\[CDATA\[[\s\S]*?]]&gt;[\s\S]*?]]>/.test(feed);
+    opens === closes && !escapedInside
+        ? pass(`feed has ${opens} balanced CDATA sections, none with an escaped ]]&gt;`)
+        : fail(
+              escapedInside
+                  ? 'a CDATA section contains ]]&gt; — entities are not parsed inside CDATA, split the section instead'
+                  : `CDATA sections do not balance: ${opens} open, ${closes} close`,
+          );
     // Attribute order is not significant in XML, so match the tag and then test its
     // attributes — the first version of this check demanded rel before href and failed on
     // a feed that xmllint and a real XML parser both accepted.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -79,6 +79,13 @@ const { heroTitle, heroSubtitle, heroImage, heroName = 'hero-image', ...seo } = 
         <link rel="manifest" href="/site.webmanifest" />
         {
             /*
+          Feed discovery. The title is what a reader's subscribe dialog shows verbatim, so
+          it names the site and what is in the feed rather than saying "RSS".
+        */
+        }
+        <link rel="alternate" type="application/rss+xml" title="Talk am Pegel — Talks" href="/rss.xml" />
+        {
+            /*
           No `preload`: <Font> preloads every face of the family, and preloading all
           six weights (144 kB) would compete with the hero image, which is the actual
           LCP element. The generated size-adjust/ascent-override fallback metrics

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -47,6 +47,7 @@ ${talkLines}
 
 ## Optional
 
+- [RSS-Feed](${base}/rss.xml): neue Ausgaben als RSS 2.0.
 - [${pageTitle('impressum')}](${base}/impressum)
 - [${pageTitle('datenschutz')}](${base}/datenschutz)
 `;

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,73 @@
+import type { APIRoute } from 'astro';
+import { talks } from '../lib/content';
+import { allTextBlocksHtml } from '../lib/talkBody';
+import { excerpt, decodeEntities } from '../lib/content';
+import { site } from '../data/site';
+
+/**
+ * RSS 2.0 feed of the talks.
+ *
+ * Why a feed on a site that publishes two or three times a year: that cadence is exactly
+ * what RSS is for — "tell me when the next Talk am Pegel is announced" — and it is a
+ * human use case, not a speculative agent one. It also closes three spec items at once:
+ * machine-readable-formats asks for a feed, and feed-discovery and feed-hygiene had been
+ * recorded as N/A *because no feed existed*, which was circular.
+ *
+ * Shape follows the feed-hygiene spec page: atom:link rel="self", per-item GUIDs that
+ * never change, RFC 822 dates, absolute URLs everywhere, and an honest sy:updatePeriod.
+ */
+const rfc822 = (d: Date) => d.toUTCString();
+const cdata = (s: string) => `<![CDATA[${s.replace(/]]>/g, ']]&gt;')}]]>`;
+const escapeXml = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+export const GET: APIRoute = async ({ site: astroSite }) => {
+    const base = astroSite!.origin;
+    const all = await talks();
+    const feedUrl = `${base}/rss.xml`;
+
+    const items = all
+        .map((talk) => {
+            const url = `${base}/talks/${talk.id}`;
+            const body = allTextBlocksHtml(talk.body ?? '');
+            // description is the list-view summary; content:encoded carries the whole
+            // thing, because "truncating feed items to a one-line teaser" is the first
+            // mistake that spec page names.
+            const summary = decodeEntities(excerpt(body, 300));
+            return `        <item>
+            <title>${escapeXml(talk.data.title)}</title>
+            <link>${url}</link>
+            <guid isPermaLink="true">${url}</guid>
+            <pubDate>${rfc822(new Date(talk.data.date))}</pubDate>
+            <category>${escapeXml(talk.data.textline)}</category>
+            <description>${cdata(summary)}</description>
+            <content:encoded>${cdata(body)}</content:encoded>
+        </item>`;
+        })
+        .join('\n');
+
+    // The newest talk's date, not the build time: a reader that polls should see
+    // lastBuildDate change when the CONTENT changes, and a deploy that fixes a typo in
+    // the footer is not a content change.
+    const newest = all[0] ? new Date(all[0].data.date) : new Date();
+
+    const body = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/">
+    <channel>
+        <title>${escapeXml(site.title)} — Talks</title>
+        <link>${base}/talks</link>
+        <description>Die Gesprächsreihe ${escapeXml(site.title)} in Neuss: neue Ausgaben, Gäste und Themen.</description>
+        <language>de-DE</language>
+        <atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />
+        <lastBuildDate>${rfc822(newest)}</lastBuildDate>
+        <sy:updatePeriod>yearly</sy:updatePeriod>
+        <sy:updateFrequency>3</sy:updateFrequency>
+${items}
+    </channel>
+</rss>
+`;
+
+    return new Response(body, { headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' } });
+};

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,7 +1,6 @@
 import type { APIRoute } from 'astro';
-import { talks } from '../lib/content';
+import { talks, excerpt, decodeEntities } from '../lib/content';
 import { allTextBlocksHtml } from '../lib/talkBody';
-import { excerpt, decodeEntities } from '../lib/content';
 import { site } from '../data/site';
 
 /**
@@ -17,7 +16,15 @@ import { site } from '../data/site';
  * never change, RFC 822 dates, absolute URLs everywhere, and an honest sy:updatePeriod.
  */
 const rfc822 = (d: Date) => d.toUTCString();
-const cdata = (s: string) => `<![CDATA[${s.replace(/]]>/g, ']]&gt;')}]]>`;
+
+/**
+ * A CDATA section cannot contain `]]>`, and it cannot be escaped either: entities are not
+ * parsed inside CDATA, so `]]&gt;` would reach the reader as those literal characters. The
+ * fix is to SPLIT the section — close it after the `]]`, reopen for the `>` — which leaves
+ * the parsed text byte-identical. Verified against a real XML parser: the entity form
+ * round-trips to `a]]&gt;b`, the split form to `a]]>b`.
+ */
+const cdata = (s: string) => `<![CDATA[${s.replace(/]]>/g, ']]]]><![CDATA[>')}]]>`;
 const escapeXml = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
 export const GET: APIRoute = async ({ site: astroSite }) => {


### PR DESCRIPTION
Fixes #1492 — by splitting it. One of its three items was worth doing; two stay declined, with better reasons than I gave when I filed it.

### Why I changed my mind on `machine-readable-formats`

I had pictured a bespoke `/talks.json` for hypothetical agents, and declined on that basis. That is not what [the item](https://specification.website/spec/agent-readiness/machine-readable-formats/) asks for. Its implementation list is: **sitemap** ✓ (have) — **a feed** ✗ — markdown sources (a separate item).

A series publishing two or three times a year is exactly what RSS is for: *"tell me when the next Talk am Pegel is announced."* That is a reader-facing feature first and an agent-facing one second, which is a much better argument than the one I declined on.

It also unwinds something circular in my own audit. #1495 records:

> **N/A groups**: … no feed → `feed-discovery`, `feed-hygiene`

Those were graded N/A **because no feed existed** — answering the question by assuming it. So one endpoint closes three items: [`machine-readable-formats`](https://specification.website/spec/agent-readiness/machine-readable-formats/), [`feed-discovery`](https://specification.website/spec/foundations/feed-discovery/) and [`feed-hygiene`](https://specification.website/spec/foundations/feed-hygiene/).

And a correction to the issue's own cost analysis: it listed "more URLs to keep in `expected-urls.txt`". Wrong — as #1488 established, non-HTML endpoints do not go in that fixture at all. `/rss.xml` sits in check 1's file list beside `sitemap.xml`.

### The feed

Shape from the feed-hygiene page, where every part has a named failure mode:

| element | why |
|---|---|
| `atom:link rel="self"` | both feed validators warn without it |
| `<guid isPermaLink="true">` = the link, never changing | readers key read-state off the GUID |
| RFC 822 `pubDate`, absolute URLs in items | a relative URL resolves against the *reader* |
| `<content:encoded>` with the full text | *"truncating feed items to a one-line teaser"* is its first listed mistake |
| `sy:updatePeriod` yearly / frequency 3 | honest about the real cadence |

`lastBuildDate` is the **newest talk's date, not the build time** — a typo fix in the footer is not a content change, and a reader polling for changes should not be told otherwise.

Discovery on all four surfaces the specs ask for: a **titled** `rel="alternate"` in the head (a subscribe dialog shows that title verbatim, so it says "Talk am Pegel — Talks" rather than "RSS"), a `Link` header relation, the api-catalog, and `llms.txt`. `_headers` types it `application/rss+xml`, because readers branch on the MIME type and Cloudflare serves `.xml` as `application/xml`.

### The two that stay declined

**`markdown-source-endpoints`** — the spec scopes it explicitly to *documentation*: *"Expose every documentation page's raw Markdown source"*, *"For documentation, serve `page.md` alongside `page.html`"*. This is not documentation, and doing it well is more than routing: CLAUDE.md records that the generated MDX carries numbered per-entry image imports and deliberately one-line blockquotes, so raw source would hand an agent build artefacts rather than clean prose. It needs an MDX→markdown render step — real work, undisclosed benefit.

**`agent-skills-discovery`** — needs an actual skill to publish, i.e. an action an agent can take. There is no API, no booking (Eventbrite handles that off-site), nothing mutable. There is nothing to declare.

### Verification

Validated with `xmllint` and a real XML parser before asserting anything. `verify.mjs` 84 → **89**:

```
✓ feed carries all 11 talks
✓ feed has an atom:link rel="self"
✓ all 11 feed items are absolute, GUID-stable, dated and un-truncated
✓ all 58 pages link the feed with a title
```

Each proven by mutation: self-link removed, a GUID decoupled from its link, content truncated to one character, an item dropped. `verify-live.sh` 35 → **37** (the feed's status and MIME type, plus `rel="alternate"` on the live `Link` header) — both confirmed failing against current production.

One of those assertions was wrong on the first attempt: it demanded `rel` before `href` on the `atom:link` and failed a feed that `xmllint` accepts. Attribute order is not significant in XML; it matches the tag and tests the attributes independently now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)