### PR TITLE
📦 Ship one FlyOnUI component instead of twenty-four

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,22 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   `lastBuildDate` is the newest talk's date, not the build time — a typo fix in the footer is not
   a content change. `_headers` types it `application/rss+xml`, because readers branch on the MIME
   type and Cloudflare would otherwise serve `.xml` as `application/xml`.
+- **Import `flyonui/dist/tooltip.js`, never `flyonui/flyonui` — and never the `.mjs`.** The
+  site uses one of FlyOnUI's 24 JS components; the full bundle costs 48.2 kB brotli against the
+  tooltip build's 10.4, and per-page JavaScript went 66.2 kB → 28.2 kB by changing that one
+  import. The `.mjs` variant of the same component is a trap: it externalises
+  `@floating-ui/dom`, so it builds clean, is 3 kB smaller, and throws
+  `(0 , i.BN) is not a function` on every page while the tooltip silently never opens. Only
+  hovering one in a real browser catches that. `verify.mjs` budgets per-page JS at 35 kB brotli
+  and fails if the other components' names (`HSDataTable`, `HSCarousel`, …) reappear in the
+  bundle.
+- **BigPicture is dynamically imported**, because 2 of 58 pages have a gallery. It lands in its
+  own 3.5 kB chunk that the other 56 never fetch — verified by watching the network, not by
+  reading the bundle. `verify.mjs` asserts it stays out of the entry script.
+- **The JS win here is bytes, not main-thread time.** Measured at 4× CPU throttling, median of
+  five runs: long tasks were **0 ms before and after**, and `domInteractive` moved 41 ms → 34 ms.
+  There was no long task to remove. Do not claim a responsiveness improvement from this change;
+  the saving is transfer size on a slow connection.
 - **`]]>` in feed content is SPLIT, never escaped.** Entities are not parsed inside a CDATA
   section, so `]]&gt;` reaches the reader as those five literal characters; closing the section
   after the `]]` and reopening for the `>` leaves the parsed text byte-identical. Verified

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -30,10 +30,13 @@
  *      scheme, and an installable manifest whose icons exist
  *  14. Discovery surface: llms.txt, the feed, security.txt and the api-catalog
  *      are well formed, advertised, and not about to expire
+ *  15. Script budget: the per-page JavaScript stays within its measured size,
+ *      and the libraries stay out of it
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
+import zlib from 'node:zlib';
 
 const DIST = 'dist';
 
@@ -962,6 +965,57 @@ console.log('\n14. Discovery surface');
     missingRels.length === 0
         ? pass(`_headers advertises ${rels.join(', ')}`)
         : fail(`_headers Link header missing rel(s): ${missingRels.join(', ')}`);
+}
+
+// ----------------------------------------------------------- 15. script budget
+console.log('\n15. Script budget');
+{
+    // What a visitor actually downloads: every <script src> a page references, brotli'd,
+    // which is how it arrives. The budget is not a round number — it is the measured cost
+    // plus headroom, and the failure it exists to catch is a one-line import going back
+    // to the whole of a library.
+    const BUDGET = 35 * 1024;
+    const brotli = (f) => zlib.brotliCompressSync(read(f)).length;
+    const perPage = new Map();
+    for (const f of pages) {
+        const refs = [...read(f).matchAll(/<script[^>]+src="(\/_astro\/[^"]+\.js)"/g)].map((m) => m[1]);
+        perPage.set(
+            toUrl(f),
+            refs.reduce((sum, r) => sum + brotli(path.join(DIST, r.replace(/^\//, ''))), 0),
+        );
+    }
+    const worst = [...perPage].sort((a, b) => b[1] - a[1])[0];
+    worst[1] <= BUDGET
+        ? pass(`heaviest page ships ${(worst[1] / 1024).toFixed(1)} kB of JS brotli (budget ${BUDGET / 1024} kB)`)
+        : fail(`${worst[0]} ships ${(worst[1] / 1024).toFixed(1)} kB of JS brotli, over the ${BUDGET / 1024} kB budget`);
+
+    const bundles = fs
+        .readdirSync(path.join(DIST, '_astro'))
+        .filter((f) => f.endsWith('.js'))
+        .map((f) => [f, read(path.join(DIST, '_astro', f))]);
+
+    // FlyOnUI ships 24 components; this site uses the tooltip. Importing
+    // `flyonui/flyonui` instead of the per-component build pulls in all of them — 48.2 kB
+    // brotli against 10.4 — so the other components' names are the fingerprint of that
+    // regression. Note `flyonui/dist/tooltip.mjs` is NOT the answer: it externalises
+    // @floating-ui/dom and throws at runtime.
+    const others = ['HSDataTable', 'HSCarousel', 'HSSelect', 'HSComboBox', 'HSFileUpload', 'HSTreeView'];
+    const leaked = bundles.flatMap(([name, code]) => others.filter((c) => code.includes(c)).map((c) => `${c} in ${name}`));
+    leaked.length === 0
+        ? pass('only the tooltip component of FlyOnUI is bundled')
+        : fail(`the full FlyOnUI bundle is back: ${leaked.slice(0, 3).join(', ')}`);
+
+    // BigPicture belongs in its own chunk: two pages of 58 have a gallery.
+    const entry = bundles.find(([name]) => name.startsWith('Layout.astro'));
+    const chunk = bundles.find(([name]) => name.startsWith('BigPicture'));
+    entry && !entry[1].includes('bigPicture') && !/BigPicture\s*=/.test(entry[1]) && chunk
+        ? pass('BigPicture is a separate chunk, not in the entry bundle')
+        : fail('BigPicture is bundled into the entry script — it should be dynamically imported');
+
+    const galleryPages = pages.filter((f) => read(f).includes('image-gallery')).length;
+    galleryPages > 0 && galleryPages < pages.length
+        ? pass(`${galleryPages} of ${pages.length} pages have a gallery, so the split earns its keep`)
+        : fail(`${galleryPages} of ${pages.length} pages have a gallery — reconsider the dynamic import`);
 }
 
 console.log(`\n${failures === 0 ? 'PASS' : 'FAIL'} — ${checks} checks passed, ${failures} failure(s)\n`);

--- a/src/scripts/site.ts
+++ b/src/scripts/site.ts
@@ -9,9 +9,21 @@
 // x-transition, x-cloak) with no registered components, so Alpine only needs to be
 // started once globally — nothing else to port.
 
-import BigPicture from 'bigpicture/src/BigPicture';
-
-import 'flyonui/flyonui';
+/*
+ * FlyOnUI's tooltip, and nothing else. `flyonui/flyonui` registers 24 components —
+ * accordion, carousel, datatable, combobox, file-upload, tree-view and the rest — to
+ * render the six tooltips on the person cards and in the footer. The per-component build
+ * self-initialises on `load` exactly as the full bundle does, so there is no init call and
+ * no markup change: 28.2 kB of JS per page instead of 66.2 (brotli).
+ *
+ * `dist/tooltip.js`, NOT `dist/tooltip.mjs`. The ESM build externalises @floating-ui/dom
+ * — FlyOnUI's own dependency, which nothing here installs at the top level — so it builds
+ * clean, ships 3 kB smaller, and throws `(0 , i.BN) is not a function` on every page while
+ * the tooltip silently never opens. The CJS build inlines the positioning engine. This was
+ * caught by hovering a tooltip in a real browser; nothing in the build output or the type
+ * checker said a word.
+ */
+import 'flyonui/dist/tooltip.js';
 
 import Alpine from 'alpinejs';
 import intersect from '@alpinejs/intersect';
@@ -23,13 +35,20 @@ Alpine.start();
 
 // Gallery lightbox: block navigation to the full-size image and hand the whole
 // .image-gallery to BigPicture so it can page through the set.
-for (const link of document.querySelectorAll<HTMLAnchorElement>('.image-gallery a')) {
-    link.addEventListener('click', (event) => {
-        event.preventDefault();
-        BigPicture({
-            el: event.target as Element,
-            imgSrc: link.getAttribute('href') as string,
-            gallery: '.image-gallery',
+//
+// Imported dynamically, because only the recap pages that have a Gallery block carry
+// `.image-gallery` — two pages out of 58. It used to load on all of them.
+const galleryLinks = document.querySelectorAll<HTMLAnchorElement>('.image-gallery a');
+if (galleryLinks.length > 0) {
+    const { default: BigPicture } = await import('bigpicture/src/BigPicture');
+    for (const link of galleryLinks) {
+        link.addEventListener('click', (event) => {
+            event.preventDefault();
+            BigPicture({
+                el: event.target as Element,
+                imgSrc: link.getAttribute('href') as string,
+                gallery: '.image-gallery',
+            });
         });
-    });
+    }
 }


### PR DESCRIPTION
Fixes #1509. **Per-page JavaScript: 66.2 kB brotli → 28.2 kB**, a 58% cut from one import and one dynamic import.

### What changed

| | before | after |
|---|---|---|
| entry bundle | 318,687 raw / **66,876 br** | 80,109 raw / **27,950 br** |
| BigPicture | inside the entry bundle, all 58 pages | own 3.5 kB chunk, fetched on **2** |
| per-page JS (worst page) | 67.8 kB br | **28.2 kB br** |

`flyonui/flyonui` registers **24** components — accordion, carousel, datatable, combobox, file-upload, tree-view and the rest — and this site uses exactly one, for the six tooltips on the person cards and in the footer. The per-component build self-initialises on `load` the same way the full bundle does, so there is no init call and no markup change.

BigPicture is now dynamically imported: 2 of 58 pages carry `.image-gallery`, and it used to load on all 58.

### The near miss

`dist/tooltip.mjs` is the obvious choice, is **3 kB smaller**, type-checks, and builds clean. It also **externalises `@floating-ui/dom`** — FlyOnUI's own dependency, which nothing installs at the top level — so it throws `(0 , i.BN) is not a function` on every page while the tooltip silently never opens.

I shipped it, measured a satisfying 63% reduction, and only found the breakage by hovering a tooltip in a real browser. `dist/tooltip.js` inlines the positioning engine. The reason is now a comment where the import is, because the smaller file is the wrong one and nothing in the toolchain says so.

Also worth admitting: my behaviour probe then called the **working** version BROKEN, because it asserted a `tooltip-shown` class that FlyOnUI does not put on the anchor. The rendered state — `opacity 0 → 1`, `visibility hidden → visible` — was right all along. Judge what the user sees, not the mechanism.

### Verified in a browser, not in the bundle

- **Tooltip opens on hover**, positioned by floating-ui (`position: fixed` with computed coordinates), label intact. That label **is the accessible name** of 120+ social links across the person pages — `verify.mjs` confirms all **795** anchors still resolve to a name.
- **Lightbox opens** on a gallery page; the BigPicture chunk is fetched **only** there; the home page never requests it.
- **Alpine still drives the reveals** and the sticky bar.
- **Zero console or page errors** across four page types — against `.mjs`, which errored on every one.

### On INP — no improvement, and this PR does not claim one

The issue asked to re-measure now that a browser harness exists. At **4× CPU throttling, median of five runs**:

| | long tasks | domInteractive |
|---|---|---|
| before | **0 ms** | 41 ms |
| after | **0 ms** | 34 ms |

There was no long task to remove. Alpine and FlyOnUI init never blocked for 50 ms even throttled, so the win here is **transfer size on a slow connection**, not responsiveness. Recorded in CLAUDE.md so nobody cites this change as an INP fix.

### Guards

`verify.mjs` gains section 15 (90 → **94**): a 35 kB brotli per-page budget computed with `zlib`, a check that the other components' names stay out of the bundle, BigPicture staying out of the entry script, and that the gallery split still earns its keep.

Proven by rebuilding with the old imports — the real regression, not a synthetic one:

```
✗ /404 ships 66.2 kB of JS brotli, over the 35 kB budget
✗ the full FlyOnUI bundle is back: HSDataTable in Layout.astro_…js, HSCarousel in …
✗ BigPicture is bundled into the entry script — it should be dynamically imported
```

### For #1487 next

This removes 24 components' worth of library code from the page, which is where `innerHTML`-style sinks were most likely to live — so the CSP work now has less to accommodate. Alpine's `new Function` evaluator remains the open question there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)