### PR TITLE
📡 Record the uptime monitor and the CAA decision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,13 @@ Alpine is used entirely as inline attributes in markup (`x-data`, `x-intersect`,
   `lastBuildDate` is the newest talk's date, not the build time — a typo fix in the footer is not
   a content change. `_headers` types it `application/rss+xml`, because readers branch on the MIME
   type and Cloudflare would otherwise serve `.xml` as `application/xml`.
+- **CAA records are deliberately absent, and uptime monitoring lives on UptimeRobot.** Both
+  decided on #1493. CAA: Cloudflare picks the issuing CA itself from four possible ones and
+  rotates roughly every 90 days, its docs state plainly that a CAA record "does not affect which
+  CA Cloudflare uses", and the CA — not Cloudflare — enforces the record at issuance. A pinned
+  record therefore fails silently into an expired certificate, and one permitting all four is
+  barely a restriction. The monitor exists but no file could show it, which is why the audit
+  filed it as missing; it is written down in `README.md` beside the other out-of-repo settings.
 - **`security.csp` in `astro.config.mjs` was evaluated and rejected — do not reach for it again
   without re-testing this.** Astro 6+ can emit the policy as a per-page `<meta http-equiv>` and
   hashes the scripts and styles it emits, which sounds strictly better than a hand-written

--- a/README.md
+++ b/README.md
@@ -182,6 +182,30 @@ Not in this repo, and not to be duplicated in `public/_headers`: HSTS, the
 and the AI-bot block that Cloudflare prepends to `robots.txt`. Setting a response header
 in both places joins the values with a comma.
 
+### Uptime monitoring
+
+An external monitor runs on **UptimeRobot**. Also outside this repo, and written down here
+for the same reason as the settings above: nothing in the codebase can show it exists, and
+an audit that cannot see it files it as missing — which is exactly what happened in
+issue #1493.
+
+It is the unattended half of `pnpm verify:live`. That script proves the edge is correct
+when someone runs it; the monitor notices when the site stops answering at all.
+
+### CAA records: deliberately absent
+
+`dig CAA talk-am-pegel.de` returns nothing, and that is a decision rather than an
+oversight. Cloudflare issues the certificate — Google Trust Services today, renewing about
+every 90 days — and chooses the CA itself from Let's Encrypt, Google Trust Services,
+SSL.com and Sectigo. Its own documentation is explicit that "CAA records are evaluated by a
+CA, not by Cloudflare" and that a CAA record "does not affect which CA Cloudflare uses".
+
+So a CAA record pinned to today's CA breaks issuance silently the first time Cloudflare
+rotates, and the symptom is an expired certificate. One permitting all four is so weak a
+restriction that it buys almost nothing for that risk. Cloudflare adds its own CAs
+alongside yours _when a CAA set exists_ — with no records at all there is nothing to add,
+which is why the "we add them automatically" line in their docs does not produce any.
+
 ## License
 
 MIT


### PR DESCRIPTION
Closes #1493 — the last open item of the audit. Documentation only; both halves resolve by decision rather than code.

### The monitor already exists

It runs on **UptimeRobot**. The audit filed it as missing because nothing in the repository could show it existed — precisely the failure mode as the Cloudflare zone settings, so it is now written down in the same place in `README.md`, next to them.

Framed there as what it actually is: the unattended half of `pnpm verify:live`. That script proves the edge is correct **when someone runs it**; the monitor notices when the site stops answering at all.

### CAA records stay absent, deliberately

You asked how to keep a CAA record current, and the answer is that you largely cannot — which is the reason not to have one here.

- Cloudflare issues the certificate (**Google Trust Services / WE1** today, valid 3 Sep → 2 Dec 2026, so renewing about every 90 days) and picks the CA itself from Let's Encrypt, Google Trust Services, SSL.com and Sectigo.
- Its own documentation is explicit: *"CAA records are evaluated by a CA, not by Cloudflare"* and a CAA record *"does not affect which CA Cloudflare uses to issue universal or advanced certificates"*.
- So a record pinned to today's issuer breaks issuance the first time Cloudflare rotates, **silently**, and surfaces as an expired certificate. One permitting all four is so weak a restriction that it buys almost nothing in exchange for that risk — for a `recommended`-tier item.

Also worth recording because it caused the confusion: the *"Cloudflare will add the CAA records on your behalf"* line is conditional on a CAA set already existing. CAA only ever restricts; with no records at all, every CA is already permitted and there is nothing for Cloudflare to add. Hence `dig CAA talk-am-pegel.de` returning empty is correct behaviour, not a broken promise.

Verified before writing it down: empty from three resolvers at both the apex and `www`, and the live certificate issuer read straight off the TLS handshake.

`pnpm verify` unchanged at 98.

---

With this merged, the audit is complete: **16 of 16**, every required item shipped and verified on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)